### PR TITLE
Fix ChartPanel reopening when closed, causing a memory leak

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 JFreeChart
 ==========
 
+This forked version from the original includes a change to fix a memory leak when using the ChartPanel:
+
+[https://github.com/jfree/jfreechart/pull/11](https://github.com/jfree/jfreechart/pull/11)
+
 Version 1.5.0 (and 1.0.20), not yet released.
 
 

--- a/src/main/java/org/jfree/chart/ChartPanel.java
+++ b/src/main/java/org/jfree/chart/ChartPanel.java
@@ -370,6 +370,9 @@ public class ChartPanel extends JPanel implements ChartChangeListener,
     /** The width of the chart buffer. */
     private int chartBufferWidth;
 
+    /** Flag to check whether the panel was disposed or not */
+    private boolean isPanelDisposed;
+
     /**
      * The minimum width for drawing a chart (uses scaling for smaller widths).
      */
@@ -1538,6 +1541,13 @@ public class ChartPanel extends JPanel implements ChartChangeListener,
      */
     @Override
     public void paintComponent(Graphics g) {
+
+        // if the Panel was disposed, do not paint the component
+        if (this.isPanelDisposed)
+        {
+            return;
+        }
+
         super.paintComponent(g);
         if (this.chart == null) {
             return;
@@ -3340,6 +3350,16 @@ public class ChartPanel extends JPanel implements ChartChangeListener,
             this.chart.addChangeListener(this);
         }
 
+    }
+
+    /**
+     * Provides a way to clean the chartBuffer and mark the ChartPanel as disposed to avoid
+     * memory bug.
+     */
+    public void dispose()
+    {
+     this.chartBuffer = null;
+     this.isPanelDisposed = true;
     }
 
 }


### PR DESCRIPTION
When closing a tab containing a ChartPanel (for the second time), after disposing the tab the ChartPanel is painted again, causing a memory leak which eventually will cause the application to crash.

Fix description: 
- Add a dispose equivalent to the ChartPanel (which uses AWT), that allows to clean the ChartBuffer (Image) causing the memory leak. 
- Add a flag to mark the ChartPanel as disposed.
- Use the flag on the painting method to prevent painting after being disposed.
