### PR TITLE
* Fixed anchor when zooming sub-plots.

### DIFF
--- a/src/main/java/org/jfree/chart/plot/CombinedDomainXYPlot.java
+++ b/src/main/java/org/jfree/chart/plot/CombinedDomainXYPlot.java
@@ -562,7 +562,8 @@ public class CombinedDomainXYPlot extends XYPlot
         // delegate 'state' and 'source' argument checks...
         XYPlot subplot = findSubplot(state, source);
         if (subplot != null) {
-            subplot.zoomRangeAxes(factor, state, source, useAnchor);
+            int subplotIndex = state.getSubplotIndex(source);
+            subplot.zoomRangeAxes(factor, state.getSubplotInfo(subplotIndex), source, useAnchor);
         } else {
             // if the source point doesn't fall within a subplot, we do the
             // zoom on all subplots...


### PR DESCRIPTION
When using the scroll-wheel to zoom on an XYPlot with sub-plots, the reference that the anchor was compared to was set to the entire plot, not the sub-plot. This made the zoom seem to use the wrong anchor point.