### PR TITLE
Bugfix for NaN ranges when combining axes

### DIFF
--- a/src/main/java/org/jfree/chart/plot/XYPlot.java
+++ b/src/main/java/org/jfree/chart/plot/XYPlot.java
@@ -4459,19 +4459,19 @@ public class XYPlot extends Plot implements ValueAxisPlot, Pannable, Zoomable,
                 XYItemRenderer r = getRendererForDataset(d);
                 if (isDomainAxis) {
                     if (r != null) {
-                        result = Range.combine(result, r.findDomainBounds(d));
+                        result = Range.combineIgnoringNaN(result, r.findDomainBounds(d));
                     }
                     else {
-                        result = Range.combine(result,
+                        result = Range.combineIgnoringNaN(result,
                                 DatasetUtilities.findDomainBounds(d));
                     }
                 }
                 else {
                     if (r != null) {
-                        result = Range.combine(result, r.findRangeBounds(d));
+                        result = Range.combineIgnoringNaN(result, r.findRangeBounds(d));
                     }
                     else {
-                        result = Range.combine(result,
+                        result = Range.combineIgnoringNaN(result,
                                 DatasetUtilities.findRangeBounds(d));
                     }
                 }
@@ -4496,10 +4496,10 @@ public class XYPlot extends Plot implements ValueAxisPlot, Pannable, Zoomable,
             XYAnnotationBoundsInfo xyabi = (XYAnnotationBoundsInfo) it.next();
             if (xyabi.getIncludeInDataBounds()) {
                 if (isDomainAxis) {
-                    result = Range.combine(result, xyabi.getXRange());
+                    result = Range.combineIgnoringNaN(result, xyabi.getXRange());
                 }
                 else {
-                    result = Range.combine(result, xyabi.getYRange());
+                    result = Range.combineIgnoringNaN(result, xyabi.getYRange());
                 }
             }
         }


### PR DESCRIPTION
This described a bug with NaN ranges:
https://sourceforge.net/p/jfreechart/bugs/1097

The proposed fix allows to combine axes with ranges like (0,0) and (NaN,NaN) without loosing the valid range.