### PR TITLE
Use a specific english locale to make month parsing in testParseMonth…

### DIFF
--- a/src/main/java/org/jfree/chart/date/SerialDate.java
+++ b/src/main/java/org/jfree/chart/date/SerialDate.java
@@ -33,6 +33,7 @@ import java.text.DateFormatSymbols;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
+import java.util.Locale;
 
 /**
  *  An abstract class that defines our requirements for manipulating dates,
@@ -59,7 +60,7 @@ public abstract class SerialDate implements Comparable, Serializable,
     
     /** Date format symbols. */
     public static final DateFormatSymbols
-        DATE_FORMAT_SYMBOLS = new SimpleDateFormat().getDateFormatSymbols();
+        DATE_FORMAT_SYMBOLS = new SimpleDateFormat("", new Locale("en", "US")).getDateFormatSymbols();
 
     /** The serial number for 1 January 1900. */
     public static final int SERIAL_LOWER_BOUND = 2;


### PR DESCRIPTION
…() locale-independent.

Fixes #46 and #33. 

--------------------

#34  did not fix the actual problem and additionally introduced new dependencies. The problem is that the parser is locale dependent. I resolved the locale-dependency by specifying a specific locale to the parser.