### PR TITLE
Add error handling code to SerialDate#addMonths and SerialDate#addYears

### DIFF
--- a/src/main/java/org/jfree/chart/date/SerialDate.java
+++ b/src/main/java/org/jfree/chart/date/SerialDate.java
@@ -540,6 +540,9 @@ public abstract class SerialDate implements Comparable, Serializable,
      */
     public static SerialDate addMonths(int months, SerialDate base) {
         int yy = (12 * base.getYYYY() + base.getMonth() + months - 1) / 12;
+        if (yy < MINIMUM_YEAR_SUPPORTED || yy > MAXIMUM_YEAR_SUPPORTED) {
+            throw new IllegalArgumentException("Call to addMonths resulted in unsupported year");
+        }
         int mm = (12 * base.getYYYY() + base.getMonth() + months - 1) % 12 + 1;
         int dd = Math.min(base.getDayOfMonth(), 
                 SerialDate.lastDayOfMonth(mm, yy));
@@ -561,6 +564,9 @@ public abstract class SerialDate implements Comparable, Serializable,
         int baseD = base.getDayOfMonth();
 
         int targetY = baseY + years;
+        if (targetY < MINIMUM_YEAR_SUPPORTED || targetY > MAXIMUM_YEAR_SUPPORTED) {
+            throw new IllegalArgumentException("Call to addYears resulted in unsupported year");
+        }
         int targetD = Math.min(baseD, SerialDate.lastDayOfMonth(baseM, targetY));
         return SerialDate.createInstance(targetD, baseM, targetY);
     }


### PR DESCRIPTION
Both `SerialDate#addMonths` and `SerialDate#addYears` adjust a date by an arbitrary integer number of months/years. The only restriction placed on this integer by the javadoc for these methods is that it "can be negative" - i.e., these methods can be used to adjust the date either forwards or backwards in time.

However, some arguments to these functions are non-sensical, and may result in opaque failures. In particular, a negative argument to `SerialDate#addMonths` with sufficiently large magnitude can cause an `ArrayIndexOutOfBoundsException` to be raised by the `SerialDate#lastDayOfMonth` function that is called later in the function, because the intermediate `mm` value that is calculated could be negative (and `lastDayOfMonth` immediately uses that value to access an array, so it must be in the range 1-12).

Since the `SerialDate` class defines a minimum and maximum year that it supports (and isn't guaranteed to work outside those bounds), this PR checks that after adding (or subtracting) the appropriate number of months/years, the resulting year is still in bounds. If not, an `IllegalArgumentException` is thrown instead. This is sufficient to prevent the out of bounds exception described above, since only arguments that would take the year out of the supported range are sufficiently negative to trigger the exception.