### PR TITLE
Ensure row keys are valid in sliding category datasets

### DIFF
--- a/src/main/java/org/jfree/data/category/SlidingCategoryDataset.java
+++ b/src/main/java/org/jfree/data/category/SlidingCategoryDataset.java
@@ -259,11 +259,14 @@ public class SlidingCategoryDataset extends AbstractDataset
     public Number getValue(Comparable rowKey, Comparable columnKey) {
         int r = getRowIndex(rowKey);
         int c = getColumnIndex(columnKey);
-        if (c != -1) {
-            return this.underlying.getValue(r, c + this.firstCategoryIndex);
+        if (c == -1) {
+            throw new UnknownKeyException("Unknown columnKey: " + columnKey);
+        }
+        else if (r == -1) {
+            throw new UnknownKeyException("Unknown rowKey: " + rowKey);
         }
         else {
-            throw new UnknownKeyException("Unknown columnKey: " + columnKey);
+            return this.underlying.getValue(r, c + this.firstCategoryIndex);
         }
     }
 

--- a/src/main/java/org/jfree/data/gantt/SlidingGanttCategoryDataset.java
+++ b/src/main/java/org/jfree/data/gantt/SlidingGanttCategoryDataset.java
@@ -258,11 +258,14 @@ public class SlidingGanttCategoryDataset extends AbstractDataset
     public Number getValue(Comparable rowKey, Comparable columnKey) {
         int r = getRowIndex(rowKey);
         int c = getColumnIndex(columnKey);
-        if (c != -1) {
-            return this.underlying.getValue(r, c + this.firstCategoryIndex);
+        if (c == -1) {
+            throw new UnknownKeyException("Unknown columnKey: " + columnKey);
+        }
+        else if (r == -1) {
+            throw new UnknownKeyException("Unknown rowKey: " + rowKey);
         }
         else {
-            throw new UnknownKeyException("Unknown columnKey: " + columnKey);
+            return this.underlying.getValue(r, c + this.firstCategoryIndex);
         }
     }
 
@@ -317,12 +320,15 @@ public class SlidingGanttCategoryDataset extends AbstractDataset
     public Number getPercentComplete(Comparable rowKey, Comparable columnKey) {
         int r = getRowIndex(rowKey);
         int c = getColumnIndex(columnKey);
-        if (c != -1) {
-            return this.underlying.getPercentComplete(r,
-                    c + this.firstCategoryIndex);
+        if (c == -1) {
+            throw new UnknownKeyException("Unknown columnKey: " + columnKey);
+        }
+        else if (r == -1) {
+            throw new UnknownKeyException("Unknown rowKey: " + rowKey);
         }
         else {
-            throw new UnknownKeyException("Unknown columnKey: " + columnKey);
+            return this.underlying.getPercentComplete(r,
+                    c + this.firstCategoryIndex);
         }
     }
 
@@ -342,12 +348,15 @@ public class SlidingGanttCategoryDataset extends AbstractDataset
             int subinterval) {
         int r = getRowIndex(rowKey);
         int c = getColumnIndex(columnKey);
-        if (c != -1) {
-            return this.underlying.getPercentComplete(r,
-                    c + this.firstCategoryIndex, subinterval);
+        if (c == -1) {
+            throw new UnknownKeyException("Unknown columnKey: " + columnKey);
+        }
+        else if (r == -1) {
+            throw new UnknownKeyException("Unknown rowKey: " + rowKey);
         }
         else {
-            throw new UnknownKeyException("Unknown columnKey: " + columnKey);
+            return this.underlying.getPercentComplete(r,
+                    c + this.firstCategoryIndex, subinterval);
         }
     }
 
@@ -367,12 +376,15 @@ public class SlidingGanttCategoryDataset extends AbstractDataset
             int subinterval) {
         int r = getRowIndex(rowKey);
         int c = getColumnIndex(columnKey);
-        if (c != -1) {
-            return this.underlying.getEndValue(r,
-                    c + this.firstCategoryIndex, subinterval);
+        if (c == -1) {
+            throw new UnknownKeyException("Unknown columnKey: " + columnKey);
+        }
+        else if (r == -1) {
+            throw new UnknownKeyException("Unknown rowKey: " + rowKey);
         }
         else {
-            throw new UnknownKeyException("Unknown columnKey: " + columnKey);
+            return this.underlying.getEndValue(r,
+                    c + this.firstCategoryIndex, subinterval);
         }
     }
 
@@ -440,12 +452,15 @@ public class SlidingGanttCategoryDataset extends AbstractDataset
             int subinterval) {
         int r = getRowIndex(rowKey);
         int c = getColumnIndex(columnKey);
-        if (c != -1) {
-            return this.underlying.getStartValue(r,
-                    c + this.firstCategoryIndex, subinterval);
+        if (c == -1) {
+            throw new UnknownKeyException("Unknown columnKey: " + columnKey);
+        }
+        else if (r == -1) {
+            throw new UnknownKeyException("Unknown rowKey: " + rowKey);
         }
         else {
-            throw new UnknownKeyException("Unknown columnKey: " + columnKey);
+            return this.underlying.getStartValue(r,
+                    c + this.firstCategoryIndex, subinterval);
         }
     }
 
@@ -480,12 +495,14 @@ public class SlidingGanttCategoryDataset extends AbstractDataset
     public int getSubIntervalCount(Comparable rowKey, Comparable columnKey) {
         int r = getRowIndex(rowKey);
         int c = getColumnIndex(columnKey);
-        if (c != -1) {
-            return this.underlying.getSubIntervalCount(r,
-                    c + this.firstCategoryIndex);
+        if (c == -1) {
+            throw new UnknownKeyException("Unknown columnKey: " + columnKey);
+        } else if (r == -1) {
+            throw new UnknownKeyException("Unknown rowKey: " + rowKey);
         }
         else {
-            throw new UnknownKeyException("Unknown columnKey: " + columnKey);
+            return this.underlying.getSubIntervalCount(r,
+                    c + this.firstCategoryIndex);
         }
     }
 
@@ -519,12 +536,14 @@ public class SlidingGanttCategoryDataset extends AbstractDataset
     public Number getStartValue(Comparable rowKey, Comparable columnKey) {
         int r = getRowIndex(rowKey);
         int c = getColumnIndex(columnKey);
-        if (c != -1) {
-            return this.underlying.getStartValue(r,
-                    c + this.firstCategoryIndex);
+        if (c == -1) {
+            throw new UnknownKeyException("Unknown columnKey: " + columnKey);
+        } else if (r == -1) {
+            throw new UnknownKeyException("Unknown rowKey: " + rowKey);
         }
         else {
-            throw new UnknownKeyException("Unknown columnKey: " + columnKey);
+            return this.underlying.getStartValue(r,
+                    c + this.firstCategoryIndex);
         }
     }
 
@@ -558,11 +577,13 @@ public class SlidingGanttCategoryDataset extends AbstractDataset
     public Number getEndValue(Comparable rowKey, Comparable columnKey) {
         int r = getRowIndex(rowKey);
         int c = getColumnIndex(columnKey);
-        if (c != -1) {
-            return this.underlying.getEndValue(r, c + this.firstCategoryIndex);
+        if (c == -1) {
+            throw new UnknownKeyException("Unknown columnKey: " + columnKey);
+        } else if (r == -1) {
+            throw new UnknownKeyException("Unknown rowKey: " + rowKey);
         }
         else {
-            throw new UnknownKeyException("Unknown columnKey: " + columnKey);
+            return this.underlying.getEndValue(r, c + this.firstCategoryIndex);
         }
     }
 

--- a/src/test/java/org/jfree/data/gantt/SlidingGanttCategoryDatasetTest.java
+++ b/src/test/java/org/jfree/data/gantt/SlidingGanttCategoryDatasetTest.java
@@ -45,8 +45,6 @@ import java.util.Date;
 import org.jfree.chart.TestUtils;
 import org.jfree.data.UnknownKeyException;
 import org.junit.Test;
-import org.junit.Rule;
-import org.junit.rules.ExpectedException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -56,9 +54,6 @@ import static org.junit.Assert.assertTrue;
  * Tests for the {@link SlidingGanttCategoryDataset} class.
  */
 public class SlidingGanttCategoryDatasetTest {
-
-    @Rule
-    public ExpectedException exceptions = ExpectedException.none();
 
     /**
      * Some checks for the equals() method.

--- a/src/test/java/org/jfree/data/gantt/SlidingGanttCategoryDatasetTest.java
+++ b/src/test/java/org/jfree/data/gantt/SlidingGanttCategoryDatasetTest.java
@@ -43,7 +43,11 @@ package org.jfree.data.gantt;
 import java.util.Date;
 
 import org.jfree.chart.TestUtils;
+import org.jfree.data.UnknownKeyException;
 import org.junit.Test;
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -52,6 +56,9 @@ import static org.junit.Assert.assertTrue;
  * Tests for the {@link SlidingGanttCategoryDataset} class.
  */
 public class SlidingGanttCategoryDatasetTest {
+
+    @Rule
+    public ExpectedException exceptions = ExpectedException.none();
 
     /**
      * Some checks for the equals() method.
@@ -142,6 +149,29 @@ public class SlidingGanttCategoryDatasetTest {
         TaskSeries s2 = u2.getSeries("Series");
         s2.add(new Task("Task 2", new Date(10L), new Date(11L)));
         assertTrue(d1.equals(d2));
+    }
+
+    /**
+     * Check that methods taking row keys and column keys throw reasonable exceptions.
+     */
+    @Test
+    public void testKeys() {
+        TaskSeries s1 = new TaskSeries("Series");
+        s1.add(new Task("Task 1", new Date(0L), new Date(1L)));
+        s1.add(new Task("Task 2", new Date(10L), new Date(11L)));
+        s1.add(new Task("Task 3", new Date(20L), new Date(21L)));
+        TaskSeriesCollection u1 = new TaskSeriesCollection();
+        u1.add(s1);
+        SlidingGanttCategoryDataset d1 = new SlidingGanttCategoryDataset(
+                u1, 0, 5);
+
+        exceptions.expect(UnknownKeyException.class);
+        exceptions.expectMessage("Unknown columnKey");
+        d1.getValue(100, 700);
+
+        exceptions.expect(UnknownKeyException.class);
+        exceptions.expectMessage("Unknown rowKey");
+        d1.getValue(0, 700);
     }
 
 }

--- a/src/test/java/org/jfree/data/gantt/SlidingGanttCategoryDatasetTest.java
+++ b/src/test/java/org/jfree/data/gantt/SlidingGanttCategoryDatasetTest.java
@@ -165,13 +165,24 @@ public class SlidingGanttCategoryDatasetTest {
         SlidingGanttCategoryDataset d1 = new SlidingGanttCategoryDataset(
                 u1, 0, 5);
 
-        exceptions.expect(UnknownKeyException.class);
-        exceptions.expectMessage("Unknown columnKey");
-        d1.getValue(100, 700);
+        boolean invalidRowKey = false;
+        try {
+            d1.getValue("Bad Value", "Task 1"); // Should be "Series", not "Bad Value"
+        } catch (UnknownKeyException e) {
+            if (e.getMessage().contains("rowKey")) {
+                invalidRowKey = true;
+            }
+        }
+        assertTrue(invalidRowKey);
 
-        exceptions.expect(UnknownKeyException.class);
-        exceptions.expectMessage("Unknown rowKey");
-        d1.getValue(0, 700);
+        boolean invalidColumnKey = false;
+        try {
+            d1.getValue("Series", "Task 4"); // only three tasks!
+        } catch (UnknownKeyException e) {
+            if (e.getMessage().contains("columnKey")) {
+                invalidColumnKey = true;
+            }
+        }
+        assertTrue(invalidColumnKey);
     }
-
 }


### PR DESCRIPTION
In `org/jfree/data/gantt/SlidingGanttCategoryDataset`, there are a number of methods that take a row key and a column key, look up indexes for them, and dispatch to the underlying dataset. In many of these methods, the column key is checked to make sure that it is valid, but the row key is not. 

For example, consider `SlidingGanttCategoryDataset#getValue`. If an invalid column key is passed, the method cleanly throws an `UnknownKeyException` at the place where the error occurred (consistent with the documentation on the method). If an invalid row key is passed, though, the error is propagated to `TaskSeriesCollection#getRowKey` (assuming that the underlying `GanttCategoryDataset` is a `TaskSeriesCollection`). This error is misleading (it's a generic `IndexOutOfBoundsException`) and doesn't really help find the bug, which was in the call to `getValue`.

While investigating, I noticed this pattern was repeated throughout this file, and I also found it in one place in `SlidingCategoryDataset`, so this PR adds checks to all of them so that the error is reported where it occurs.