### PR TITLE
Fix incorrect return value in DefaultKeyedValues2D#getRowIndex

### DIFF
--- a/src/main/java/org/jfree/data/DefaultKeyedValues2D.java
+++ b/src/main/java/org/jfree/data/DefaultKeyedValues2D.java
@@ -187,7 +187,10 @@ public class DefaultKeyedValues2D implements KeyedValues2D, PublicCloneable,
     public int getRowIndex(Comparable key) {
         Args.nullNotPermitted(key, "key");
         if (this.sortRowKeys) {
-            return Collections.binarySearch(this.rowKeys, key);
+            int index = Collections.binarySearch(this.rowKeys, key);
+            if (index < 0) {
+                return -1;
+            }
         }
         else {
             return this.rowKeys.indexOf(key);

--- a/src/main/java/org/jfree/data/DefaultKeyedValues2D.java
+++ b/src/main/java/org/jfree/data/DefaultKeyedValues2D.java
@@ -190,6 +190,8 @@ public class DefaultKeyedValues2D implements KeyedValues2D, PublicCloneable,
             int index = Collections.binarySearch(this.rowKeys, key);
             if (index < 0) {
                 return -1;
+            } else {
+                return index;
             }
         }
         else {


### PR DESCRIPTION
DefaultKeyedValues2D#getRowIndex returns the result of Collections.binarySearch directly if the underlying List is being kept in sorted order. The specification for [Collections.binarySearch](https://docs.oracle.com/javase/7/docs/api/java/util/Collections.html#binarySearch(java.util.List,%20T)) is unusual: if the element being searched for is not found, a negative index indicating where to insert the value to keep the list in sorted order is returned. The specification on getRowIndex, defined in the KeyedValues2D interface, says:
 ``` * @return The row index, or {@code -1} if the key is unrecognised```. 

This pull request changes DefaultKeyedValues2D#getRowIndex to respect the specification written on KeyedValues2D#getRowIndex; an alternative option would be to change the spec there to allow a negative index to be returned.