### PR TITLE
Remove name fields from enum

### DIFF
--- a/src/main/java/org/jfree/chart/ui/Layer.java
+++ b/src/main/java/org/jfree/chart/ui/Layer.java
@@ -34,33 +34,9 @@ package org.jfree.chart.ui;
 public enum Layer {
 
     /** Foreground. */
-    FOREGROUND("Layer.FOREGROUND"),
+    FOREGROUND,
 
     /** Background. */
-    BACKGROUND("Layer.BACKGROUND");
-
-    /** The name. */
-    private String name;
-
-    /**
-     * Private constructor.
-     *
-     * @param name  the name.
-     */
-    private Layer(final String name) {
-        this.name = name;
-    }
-
-    /**
-     * Returns a string representing the object.
-     *
-     * @return The string.
-     */
-    @Override
-    public String toString() {
-        return this.name;
-    }
+    BACKGROUND
 
 }
-
-

--- a/src/main/java/org/jfree/chart/ui/RectangleAnchor.java
+++ b/src/main/java/org/jfree/chart/ui/RectangleAnchor.java
@@ -38,43 +38,31 @@ import org.jfree.chart.util.Args;
 public enum RectangleAnchor {
 
     /** Center. */
-    CENTER("RectangleAnchor.CENTER"),
+    CENTER,
 
     /** Top. */
-    TOP("RectangleAnchor.TOP"),
+    TOP,
 
     /** Top-Left. */
-    TOP_LEFT("RectangleAnchor.TOP_LEFT"),
+    TOP_LEFT,
 
     /** Top-Right. */
-    TOP_RIGHT("RectangleAnchor.TOP_RIGHT"),
+    TOP_RIGHT,
 
     /** Bottom. */
-    BOTTOM("RectangleAnchor.BOTTOM"),
+    BOTTOM,
 
     /** Bottom-Left. */
-    BOTTOM_LEFT("RectangleAnchor.BOTTOM_LEFT"),
+    BOTTOM_LEFT,
 
     /** Bottom-Right. */
-    BOTTOM_RIGHT("RectangleAnchor.BOTTOM_RIGHT"),
+    BOTTOM_RIGHT,
 
     /** Left. */
-    LEFT("RectangleAnchor.LEFT"),
+    LEFT,
 
     /** Right. */
-    RIGHT("RectangleAnchor.RIGHT");
-
-    /** The name. */
-    private final String name;
-
-    /**
-     * Private constructor.
-     *
-     * @param name  the name.
-     */
-    private RectangleAnchor(String name) {
-        this.name = name;
-    }
+    RIGHT;
 
     /**
      * Returns the anchor point relative to the specified rectangle.
@@ -106,16 +94,6 @@ public enum RectangleAnchor {
             result.setLocation(rectangle.getMaxX(), rectangle.getMaxY());
         }
         return result;
-    }
-
-    /**
-     * Returns a string representing the object.
-     *
-     * @return The string.
-     */
-    @Override
-    public String toString() {
-        return this.name;
     }
     
     /**

--- a/src/main/java/org/jfree/chart/util/Rotation.java
+++ b/src/main/java/org/jfree/chart/util/Rotation.java
@@ -35,13 +35,10 @@ package org.jfree.chart.util;
 public enum Rotation {
 
     /** Clockwise. */
-    CLOCKWISE("Rotation.CLOCKWISE", -1.0),
+    CLOCKWISE(-1.0),
 
     /** The reverse order renders the primary dataset first. */
-    ANTICLOCKWISE("Rotation.ANTICLOCKWISE", 1.0);
-
-    /** The name. */
-    private String name;
+    ANTICLOCKWISE(1.0);
 
     /**
      * The factor (-1.0 for {@code CLOCKWISE} and 1.0 for
@@ -52,22 +49,10 @@ public enum Rotation {
     /**
      * Private constructor.
      *
-     * @param name  the name.
      * @param factor  the rotation factor.
      */
-    private Rotation(String name, double factor) {
-        this.name = name;
+    Rotation(double factor) {
         this.factor = factor;
-    }
-
-    /**
-     * Returns a string representing the object.
-     *
-     * @return the string (never {@code null}).
-     */
-    @Override
-    public String toString() {
-        return this.name;
     }
 
     /**

--- a/src/main/java/org/jfree/chart/util/SortOrder.java
+++ b/src/main/java/org/jfree/chart/util/SortOrder.java
@@ -34,31 +34,9 @@ package org.jfree.chart.util;
 public enum SortOrder {
 
     /** Ascending order. */
-    ASCENDING("SortOrder.ASCENDING"),
+    ASCENDING,
 
     /** Descending order. */
-    DESCENDING("SortOrder.DESCENDING");
-
-    /** The name. */
-    private final String name;
-
-    /**
-     * Private constructor.
-     *
-     * @param name  the name.
-     */
-    private SortOrder(String name) {
-        this.name = name;
-    }
-
-    /**
-     * Returns a string representing the object.
-     *
-     * @return The string.
-     */
-    @Override
-    public String toString() {
-        return this.name;
-    }
+    DESCENDING
 
 }

--- a/src/main/java/org/jfree/chart/util/TableOrder.java
+++ b/src/main/java/org/jfree/chart/util/TableOrder.java
@@ -34,31 +34,10 @@ package org.jfree.chart.util;
 public enum TableOrder {
 
     /** By row. */
-    BY_ROW("TableOrder.BY_ROW"),
+    BY_ROW,
 
     /** By column. */
-    BY_COLUMN("TableOrder.BY_COLUMN");
+    BY_COLUMN
 
-    /** The name. */
-    private final String name;
-
-    /**
-     * Private constructor.
-     *
-     * @param name  the name.
-     */
-    private TableOrder(String name) {
-        this.name = name;
-    }
-
-    /**
-     * Returns a string representing the object.
-     *
-     * @return The string.
-     */
-    @Override
-    public String toString() {
-        return this.name;
-    }
 }
 

--- a/src/main/java/org/jfree/chart/util/UnitType.java
+++ b/src/main/java/org/jfree/chart/util/UnitType.java
@@ -34,30 +34,9 @@ package org.jfree.chart.util;
 public enum UnitType {
 
     /** Absolute. */
-    ABSOLUTE("UnitType.ABSOLUTE"),
+    ABSOLUTE,
 
     /** Relative. */
-    RELATIVE("UnitType.RELATIVE");
+    RELATIVE
 
-    /** The name. */
-    private final String name;
-
-    /**
-     * Private constructor.
-     *
-     * @param name  the name.
-     */
-    private UnitType(String name) {
-        this.name = name;
-    }
-
-    /**
-     * Returns a string representing the object.
-     *
-     * @return The string.
-     */
-    @Override
-    public String toString() {
-        return this.name;
-    }    
 }


### PR DESCRIPTION
This seems superflous since `toString()` is generated automatically.