### PR TITLE
fixed SamplingXYLineRenderer to draw seriesPath from s.closeY instead of from last drawn y

### DIFF
--- a/src/main/java/org/jfree/chart/renderer/xy/SamplingXYLineRenderer.java
+++ b/src/main/java/org/jfree/chart/renderer/xy/SamplingXYLineRenderer.java
@@ -261,11 +261,13 @@ public class SamplingXYLineRenderer extends AbstractXYItemRenderer
             }
             if (s.lastPointGood) {
                 if ((Math.abs(x - s.lastX) > s.dX)) {
-                    s.seriesPath.lineTo(x, y);
                     if (s.lowY < s.highY) {
                         s.intervalPath.moveTo((float) s.lastX, (float) s.lowY);
                         s.intervalPath.lineTo((float) s.lastX, (float) s.highY);
+
+                        s.seriesPath.moveTo((float) s.lastX, (float) s.closeY);
                     }
+                    s.seriesPath.lineTo(x, y);
                     s.lastX = x;
                     s.openY = y;
                     s.highY = y;


### PR DESCRIPTION
We had the problem, that the line to the next point started from a wrong y-value. The starting point was not the last processed y-value but it was the last drawn y-value.

For example: 
        final XYSeries series = new XYSeries( "Example" );
        series.add( 0.5 , 5.0 );
        series.add( 1.0 , 5.0 );
        series.add( 1.0001 , 2.0 );
        series.add( 1.0002 , 10.0 );
        series.add( 1.0003 , 1.0 );
        series.add( 2.0 , 5.0 );

With this dataset, the line from x=1.0 to x=2.0 started at y=5.0 but we expected that it would start at y=1.0 because it's the last x-value before x=2.0. With the bugfix the line goes from 1.0003/1.0 to 2.0/5.0.