### PR TITLE
Fixing flaky test DayTest.testParseDay

### DIFF
--- a/src/test/java/org/jfree/chart/axis/PeriodAxisTest.java
+++ b/src/test/java/org/jfree/chart/axis/PeriodAxisTest.java
@@ -268,6 +268,7 @@ public class PeriodAxisTest implements AxisChangeListener {
      */
     @Test
     public void test2490803() {
+        new Day();  // Initialize Day class before changing default locale and time zone
         Locale savedLocale = Locale.getDefault();
         TimeZone savedTimeZone = TimeZone.getDefault();
         try {


### PR DESCRIPTION
Test DayTest.testParseDay fails when run after PeriodAxisTest.test2490803. test2490803 initializes the Day class after it changes the default locale and time zone, so Day's DATE_FORMAT field gets initialized with a different locale and time zone, causing testParseDay to later fail. The proposed fix purposely initializes the Day class before default locale and time zone are modified.