### PR TITLE
AbstractXYItemRenderer should implement PublicCloneable

### DIFF
--- a/src/main/java/org/jfree/chart/renderer/xy/AbstractXYItemRenderer.java
+++ b/src/main/java/org/jfree/chart/renderer/xy/AbstractXYItemRenderer.java
@@ -195,7 +195,7 @@ import org.jfree.data.xy.XYItemKey;
  * implementations.
  */
 public abstract class AbstractXYItemRenderer extends AbstractRenderer
-        implements XYItemRenderer, AnnotationChangeListener,
+        implements XYItemRenderer, AnnotationChangeListener, PublicCloneable,
         Cloneable, Serializable {
 
     /** For serialization. */
@@ -1450,7 +1450,7 @@ public abstract class AbstractXYItemRenderer extends AbstractRenderer
      *         cloning.
      */
     @Override
-    protected Object clone() throws CloneNotSupportedException {
+    public Object clone() throws CloneNotSupportedException {
         AbstractXYItemRenderer clone = (AbstractXYItemRenderer) super.clone();
         // 'plot' : just retain reference, not a deep copy
 


### PR DESCRIPTION
When trying to build with Java 11 project which is using Jfreecharts as Gradle dependency build fails. 
The error suggests that AbstractXYItemRenderer should implement PublicCloneable. 
After introducing the following changes everything works fine.