### PR TITLE
Add tests for org.jfree.chart.imagemap.ImageMapUtils

### DIFF
--- a/src/test/java/org/jfree/chart/imagemap/ImageMapUtilsTest.java
+++ b/src/test/java/org/jfree/chart/imagemap/ImageMapUtilsTest.java
@@ -40,13 +40,25 @@
 
 package org.jfree.chart.imagemap;
 
-import static org.junit.Assert.assertEquals;
+import org.jfree.chart.ChartRenderingInfo;
+import org.jfree.chart.entity.ChartEntity;
+import org.jfree.chart.entity.EntityCollection;
+import org.jfree.chart.entity.StandardEntityCollection;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.awt.Rectangle;
+import java.awt.Shape;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * Tests for the {@link ImageMapUtils} class.
  */
 public class ImageMapUtilsTest {
+
+    @Rule public ExpectedException thrown = ExpectedException.none();
 
     /**
      * Some checks for the htmlEscape() method.
@@ -76,4 +88,34 @@ public class ImageMapUtilsTest {
         assertEquals("\\\\", ImageMapUtils.javascriptEscape("\\"));
     }
 
+    @Test
+    public void testGetImageMap() {
+        final Shape shape = new Rectangle(1, 2, 3, 4);
+        final Shape shape2 = new Rectangle(5, 6, 7, 8);
+
+        EntityCollection entities = new StandardEntityCollection();
+
+        entities.add(new ChartEntity(shape, "toolTip1", "URL1"));
+        entities.add(new ChartEntity(shape2, "toolTip2", "URL2"));
+
+        final String retval = ImageMapUtils.getImageMap("name", new ChartRenderingInfo(entities),
+                new StandardToolTipTagFragmentGenerator(), new StandardURLTagFragmentGenerator());
+
+        assertEquals("<map id=\"name\" name=\"name\">\n" +
+                "<area shape=\"rect\" coords=\"5,6,12,14\" title=\"toolTip2\" alt=\"\" href=\"URL2\"/>\n" +
+                "<area shape=\"rect\" coords=\"1,2,4,6\" title=\"toolTip1\" alt=\"\" href=\"URL1\"/>\n" +
+                "</map>", retval);
+    }
+
+    @Test
+    public void testGetImageMapIllegalArgumentException() {
+        thrown.expect(IllegalArgumentException.class);
+        ImageMapUtils.getImageMap(null, null, null, null);
+    }
+
+    @Test
+    public void testGetImageMapIllegalArgumentException_2() {
+        thrown.expect(IllegalArgumentException.class);
+        ImageMapUtils.getImageMap(null, null);
+    }
 }


### PR DESCRIPTION
Hi,
I've analysed your codebase and noticed that `org.jfree.chart.imagemap.ImageMapUtils` is not fully tested. Subsequently, I've written tests for the `GetImageMap` function with the help of [Diffblue](https://www.diffblue.com/) [Cover](https://www.diffblue.com/datasheet).

Hopefully, these tests should help you detect regressions caused by future code changes. If you have any other classes you would like additional unit tests for, please let me know and I'll be happy to contribute additional tests. 