### PR TITLE
Fix XYAreaRenderer to use SeriesFillPaint when not a Gradient

### DIFF
--- a/src/main/java/org/jfree/chart/renderer/xy/XYAreaRenderer.java
+++ b/src/main/java/org/jfree/chart/renderer/xy/XYAreaRenderer.java
@@ -604,6 +604,7 @@ public class XYAreaRenderer extends AbstractXYItemRenderer
 
             if (this.useFillPaint) {
                 paint = lookupSeriesFillPaint(series);
+                g2.setPaint(paint);
             }
             if (paint instanceof GradientPaint) {
                 GradientPaint gp = (GradientPaint) paint;


### PR DESCRIPTION
If you set SeriesFillPaint with a color that is not a gradient, it will be ignored, and the SeriesPaint will be used instead.