### PR TITLE
Allow to set thread-local calendars and calendar prototype for RegularTimePeriod

### DIFF
--- a/src/main/java/org/jfree/data/time/Day.java
+++ b/src/main/java/org/jfree/data/time/Day.java
@@ -40,10 +40,8 @@ import java.io.Serializable;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.Locale;
-import java.util.TimeZone;
+import java.util.*;
+
 import org.jfree.chart.date.SerialDate;
 import org.jfree.chart.util.Args;
 
@@ -86,8 +84,9 @@ public class Day extends RegularTimePeriod implements Serializable {
     private long lastMillisecond;
 
     /**
-     * Creates a new instance, derived from the system date/time (and assuming
-     * the default timezone).
+     * Creates a new instance, derived from the system date/time.
+     * The time zone and locale are determined by the calendar
+     * returned by {@link RegularTimePeriod#getCalendarInstance()}.
      */
     public Day() {
         this(new Date());
@@ -95,6 +94,8 @@ public class Day extends RegularTimePeriod implements Serializable {
 
     /**
      * Constructs a new one day time period.
+     * The time zone and locale are determined by the calendar
+     * returned by {@link RegularTimePeriod#getCalendarInstance()}.
      *
      * @param day  the day-of-the-month.
      * @param month  the month (1 to 12).
@@ -102,23 +103,26 @@ public class Day extends RegularTimePeriod implements Serializable {
      */
     public Day(int day, int month, int year) {
         this.serialDate = SerialDate.createInstance(day, month, year);
-        peg(Calendar.getInstance());
+        peg(getCalendarInstance());
     }
 
     /**
      * Constructs a new one day time period.
+     * The time zone and locale are determined by the calendar
+     * returned by {@link RegularTimePeriod#getCalendarInstance()}.
      *
      * @param serialDate  the day ({@code null} not permitted).
      */
     public Day(SerialDate serialDate) {
         Args.nullNotPermitted(serialDate, "serialDate");
         this.serialDate = serialDate;
-        peg(Calendar.getInstance());
+        peg(getCalendarInstance());
     }
 
     /**
-     * Constructs a new instance, based on a particular date/time and the
-     * default time zone.
+     * Constructs a new instance, based on a particular date/time.
+     * The time zone and locale are determined by the calendar
+     * returned by {@link RegularTimePeriod#getCalendarInstance()}.
      *
      * @param time  the time ({@code null} not permitted).
      *
@@ -126,7 +130,7 @@ public class Day extends RegularTimePeriod implements Serializable {
      */
     public Day(Date time) {
         // defer argument checking...
-        this(time, TimeZone.getDefault(), Locale.getDefault());
+        this(time, getCalendarInstance());
     }
 
     /**
@@ -142,11 +146,31 @@ public class Day extends RegularTimePeriod implements Serializable {
         Args.nullNotPermitted(locale, "locale");
         Calendar calendar = Calendar.getInstance(zone, locale);
         calendar.setTime(time);
+        initUsing(calendar);
+        peg(calendar);
+    }
+
+    /**
+     * Constructs a new instance, based on a particular date/time.
+     * The time zone and locale are determined by the {@code calendar}
+     * parameter.
+     *
+     * @param time the date/time ({@code null} not permitted).
+     * @param calendar the calendar to use for calculations ({@code null} not permitted).
+     */
+    public Day(Date time, Calendar calendar) {
+        Args.nullNotPermitted(time, "time");
+        Args.nullNotPermitted(calendar, "calendar");
+        calendar.setTime(time);
+        initUsing(calendar);
+        peg(calendar);
+    }
+
+    private void initUsing(Calendar calendar) {
         int d = calendar.get(Calendar.DAY_OF_MONTH);
         int m = calendar.get(Calendar.MONTH) + 1;
         int y = calendar.get(Calendar.YEAR);
         this.serialDate = SerialDate.createInstance(d, m, y);
-        peg(calendar);
     }
 
     /**
@@ -235,6 +259,9 @@ public class Day extends RegularTimePeriod implements Serializable {
 
     /**
      * Returns the day preceding this one.
+     * No matter what time zone and locale this instance was created with,
+     * the returned instance will use the default calendar for time
+     * calculations, obtained with {@link RegularTimePeriod#getCalendarInstance()}.
      *
      * @return The day preceding this one.
      */
@@ -255,6 +282,9 @@ public class Day extends RegularTimePeriod implements Serializable {
     /**
      * Returns the day following this one, or {@code null} if some limit
      * has been reached.
+     * No matter what time zone and locale this instance was created with,
+     * the returned instance will use the default calendar for time
+     * calculations, obtained with {@link RegularTimePeriod#getCalendarInstance()}.
      *
      * @return The day following this one, or {@code null} if some limit
      *         has been reached.

--- a/src/main/java/org/jfree/data/time/Hour.java
+++ b/src/main/java/org/jfree/data/time/Hour.java
@@ -72,6 +72,8 @@ public class Hour extends RegularTimePeriod implements Serializable {
 
     /**
      * Constructs a new Hour, based on the system date/time.
+     * The time zone and locale are determined by the calendar
+     * returned by {@link RegularTimePeriod#getCalendarInstance()}.
      */
     public Hour() {
         this(new Date());
@@ -79,6 +81,8 @@ public class Hour extends RegularTimePeriod implements Serializable {
 
     /**
      * Constructs a new Hour.
+     * The time zone and locale are determined by the calendar
+     * returned by {@link RegularTimePeriod#getCalendarInstance()}.
      *
      * @param hour  the hour (in the range 0 to 23).
      * @param day  the day ({@code null} not permitted).
@@ -87,11 +91,13 @@ public class Hour extends RegularTimePeriod implements Serializable {
         Args.nullNotPermitted(day, "day");
         this.hour = (byte) hour;
         this.day = day;
-        peg(Calendar.getInstance());
+        peg(getCalendarInstance());
     }
 
     /**
      * Creates a new hour.
+     * The time zone and locale are determined by the calendar
+     * returned by {@link RegularTimePeriod#getCalendarInstance()}.
      *
      * @param hour  the hour (0-23).
      * @param day  the day (1-31).
@@ -103,8 +109,9 @@ public class Hour extends RegularTimePeriod implements Serializable {
     }
 
     /**
-     * Constructs a new instance, based on the supplied date/time and
-     * the default time zone.
+     * Constructs a new instance, based on the supplied date/time.
+     * The time zone and locale are determined by the calendar
+     * returned by {@link RegularTimePeriod#getCalendarInstance()}.
      *
      * @param time  the date-time ({@code null} not permitted).
      *
@@ -112,7 +119,7 @@ public class Hour extends RegularTimePeriod implements Serializable {
      */
     public Hour(Date time) {
         // defer argument checking...
-        this(time, TimeZone.getDefault(), Locale.getDefault());
+        this(time, getCalendarInstance());
     }
 
     /**
@@ -133,6 +140,23 @@ public class Hour extends RegularTimePeriod implements Serializable {
         calendar.setTime(time);
         this.hour = (byte) calendar.get(Calendar.HOUR_OF_DAY);
         this.day = new Day(time, zone, locale);
+        peg(calendar);
+    }
+
+    /**
+     * Constructs a new instance, based on a particular date/time.
+     * The time zone and locale are determined by the {@code calendar}
+     * parameter.
+     *
+     * @param time the date/time ({@code null} not permitted).
+     * @param calendar the calendar to use for calculations ({@code null} not permitted).
+     */
+    public Hour(Date time, Calendar calendar) {
+        Args.nullNotPermitted(time, "time");
+        Args.nullNotPermitted(calendar, "calendar");
+        calendar.setTime(time);
+        this.hour = (byte) calendar.get(Calendar.HOUR_OF_DAY);
+        this.day = new Day(time, calendar);
         peg(calendar);
     }
 
@@ -227,6 +251,9 @@ public class Hour extends RegularTimePeriod implements Serializable {
 
     /**
      * Returns the hour preceding this one.
+     * No matter what time zone and locale this instance was created with,
+     * the returned instance will use the default calendar for time
+     * calculations, obtained with {@link RegularTimePeriod#getCalendarInstance()}.
      *
      * @return The hour preceding this one.
      */
@@ -250,6 +277,9 @@ public class Hour extends RegularTimePeriod implements Serializable {
 
     /**
      * Returns the hour following this one.
+     * No matter what time zone and locale this instance was created with,
+     * the returned instance will use the default calendar for time
+     * calculations, obtained with {@link RegularTimePeriod#getCalendarInstance()}.
      *
      * @return The hour following this one.
      */

--- a/src/main/java/org/jfree/data/time/Millisecond.java
+++ b/src/main/java/org/jfree/data/time/Millisecond.java
@@ -36,6 +36,8 @@
 
 package org.jfree.data.time;
 
+import org.jfree.chart.util.Args;
+
 import java.io.Serializable;
 import java.util.Calendar;
 import java.util.Date;
@@ -79,6 +81,8 @@ public class Millisecond extends RegularTimePeriod implements Serializable {
 
     /**
      * Constructs a millisecond based on the current system time.
+     * The time zone and locale are determined by the calendar
+     * returned by {@link RegularTimePeriod#getCalendarInstance()}.
      */
     public Millisecond() {
         this(new Date());
@@ -86,21 +90,26 @@ public class Millisecond extends RegularTimePeriod implements Serializable {
 
     /**
      * Constructs a millisecond.
+     * The time zone and locale are determined by the calendar
+     * returned by {@link RegularTimePeriod#getCalendarInstance()}.
      *
      * @param millisecond  the millisecond (0-999).
-     * @param second  the second.
+     * @param second  the second ({@code null} not permitted).
      */
     public Millisecond(int millisecond, Second second) {
+        Args.nullNotPermitted(second, "second");
         this.millisecond = millisecond;
         this.second = (byte) second.getSecond();
         this.minute = (byte) second.getMinute().getMinute();
         this.hour = (byte) second.getMinute().getHourValue();
         this.day = second.getMinute().getDay();
-        peg(Calendar.getInstance());
+        peg(getCalendarInstance());
     }
 
     /**
      * Creates a new millisecond.
+     * The time zone and locale are determined by the calendar
+     * returned by {@link RegularTimePeriod#getCalendarInstance()}.
      *
      * @param millisecond  the millisecond (0-999).
      * @param second  the second (0-59).
@@ -118,14 +127,16 @@ public class Millisecond extends RegularTimePeriod implements Serializable {
     }
 
     /**
-     * Constructs a new millisecond using the default time zone.
+     * Constructs a new millisecond.
+     * The time zone and locale are determined by the calendar
+     * returned by {@link RegularTimePeriod#getCalendarInstance()}.
      *
      * @param time  the time.
      *
      * @see #Millisecond(Date, TimeZone, Locale)
      */
     public Millisecond(Date time) {
-        this(time, TimeZone.getDefault(), Locale.getDefault());
+        this(time, getCalendarInstance());
     }
 
     /**
@@ -138,6 +149,9 @@ public class Millisecond extends RegularTimePeriod implements Serializable {
      * @since 1.0.13
      */
     public Millisecond(Date time, TimeZone zone, Locale locale) {
+        Args.nullNotPermitted(time, "time");
+        Args.nullNotPermitted(zone, "zone");
+        Args.nullNotPermitted(locale, "locale");
         Calendar calendar = Calendar.getInstance(zone, locale);
         calendar.setTime(time);
         this.millisecond = calendar.get(Calendar.MILLISECOND);
@@ -145,6 +159,26 @@ public class Millisecond extends RegularTimePeriod implements Serializable {
         this.minute = (byte) calendar.get(Calendar.MINUTE);
         this.hour = (byte) calendar.get(Calendar.HOUR_OF_DAY);
         this.day = new Day(time, zone, locale);
+        peg(calendar);
+    }
+
+    /**
+     * Constructs a new instance, based on a particular date/time.
+     * The time zone and locale are determined by the {@code calendar}
+     * parameter.
+     *
+     * @param time the date/time ({@code null} not permitted).
+     * @param calendar the calendar to use for calculations ({@code null} not permitted).
+     */
+    public Millisecond(Date time, Calendar calendar) {
+        Args.nullNotPermitted(time, "time");
+        Args.nullNotPermitted(calendar, "calendar");
+        calendar.setTime(time);
+        this.millisecond = calendar.get(Calendar.MILLISECOND);
+        this.second = (byte) calendar.get(Calendar.SECOND);
+        this.minute = (byte) calendar.get(Calendar.MINUTE);
+        this.hour = (byte) calendar.get(Calendar.HOUR_OF_DAY);
+        this.day = new Day(time, calendar);
         peg(calendar);
     }
 
@@ -213,6 +247,9 @@ public class Millisecond extends RegularTimePeriod implements Serializable {
 
     /**
      * Returns the millisecond preceding this one.
+     * No matter what time zone and locale this instance was created with,
+     * the returned instance will use the default calendar for time
+     * calculations, obtained with {@link RegularTimePeriod#getCalendarInstance()}.
      *
      * @return The millisecond preceding this one.
      */
@@ -233,6 +270,9 @@ public class Millisecond extends RegularTimePeriod implements Serializable {
 
     /**
      * Returns the millisecond following this one.
+     * No matter what time zone and locale this instance was created with,
+     * the returned instance will use the default calendar for time
+     * calculations, obtained with {@link RegularTimePeriod#getCalendarInstance()}.
      *
      * @return The millisecond following this one.
      */

--- a/src/main/java/org/jfree/data/time/Minute.java
+++ b/src/main/java/org/jfree/data/time/Minute.java
@@ -75,6 +75,8 @@ public class Minute extends RegularTimePeriod implements Serializable {
 
     /**
      * Constructs a new Minute, based on the system date/time.
+     * The time zone and locale are determined by the calendar
+     * returned by {@link RegularTimePeriod#getCalendarInstance()}.
      */
     public Minute() {
         this(new Date());
@@ -82,6 +84,8 @@ public class Minute extends RegularTimePeriod implements Serializable {
 
     /**
      * Constructs a new Minute.
+     * The time zone and locale are determined by the calendar
+     * returned by {@link RegularTimePeriod#getCalendarInstance()}.
      *
      * @param minute  the minute (0 to 59).
      * @param hour  the hour ({@code null} not permitted).
@@ -91,12 +95,13 @@ public class Minute extends RegularTimePeriod implements Serializable {
         this.minute = (byte) minute;
         this.hour = (byte) hour.getHour();
         this.day = hour.getDay();
-        peg(Calendar.getInstance());
+        peg(getCalendarInstance());
     }
 
     /**
-     * Constructs a new instance, based on the supplied date/time and
-     * the default time zone.
+     * Constructs a new instance, based on the supplied date/time.
+     * The time zone and locale are determined by the calendar
+     * returned by {@link RegularTimePeriod#getCalendarInstance()}.
      *
      * @param time  the time ({@code null} not permitted).
      *
@@ -104,7 +109,7 @@ public class Minute extends RegularTimePeriod implements Serializable {
      */
     public Minute(Date time) {
         // defer argument checking
-        this(time, TimeZone.getDefault(), Locale.getDefault());
+        this(time, getCalendarInstance());
     }
 
     /**
@@ -130,7 +135,28 @@ public class Minute extends RegularTimePeriod implements Serializable {
     }
 
     /**
+     * Constructs a new instance, based on a particular date/time.
+     * The time zone and locale are determined by the {@code calendar}
+     * parameter.
+     *
+     * @param time the date/time ({@code null} not permitted).
+     * @param calendar the calendar to use for calculations ({@code null} not permitted).
+     */
+    public Minute(Date time, Calendar calendar) {
+        Args.nullNotPermitted(time, "time");
+        Args.nullNotPermitted(calendar, "calendar");
+        calendar.setTime(time);
+        int min = calendar.get(Calendar.MINUTE);
+        this.minute = (byte) min;
+        this.hour = (byte) calendar.get(Calendar.HOUR_OF_DAY);
+        this.day = new Day(time, calendar);
+        peg(calendar);
+    }
+
+    /**
      * Creates a new minute.
+     * The time zone and locale are determined by the calendar
+     * returned by {@link RegularTimePeriod#getCalendarInstance()}.
      *
      * @param minute  the minute (0-59).
      * @param hour  the hour (0-23).
@@ -228,6 +254,9 @@ public class Minute extends RegularTimePeriod implements Serializable {
 
     /**
      * Returns the minute preceding this one.
+     * No matter what time zone and locale this instance was created with,
+     * the returned instance will use the default calendar for time
+     * calculations, obtained with {@link RegularTimePeriod#getCalendarInstance()}.
      *
      * @return The minute preceding this one.
      */
@@ -251,6 +280,9 @@ public class Minute extends RegularTimePeriod implements Serializable {
 
     /**
      * Returns the minute following this one.
+     * No matter what time zone and locale this instance was created with,
+     * the returned instance will use the default calendar for time
+     * calculations, obtained with {@link RegularTimePeriod#getCalendarInstance()}.
      *
      * @return The minute following this one.
      */

--- a/src/main/java/org/jfree/data/time/Month.java
+++ b/src/main/java/org/jfree/data/time/Month.java
@@ -67,6 +67,8 @@ public class Month extends RegularTimePeriod implements Serializable {
 
     /**
      * Constructs a new Month, based on the current system time.
+     * The time zone and locale are determined by the calendar
+     * returned by {@link RegularTimePeriod#getCalendarInstance()}.
      */
     public Month() {
         this(new Date());
@@ -74,6 +76,8 @@ public class Month extends RegularTimePeriod implements Serializable {
 
     /**
      * Constructs a new month instance.
+     * The time zone and locale are determined by the calendar
+     * returned by {@link RegularTimePeriod#getCalendarInstance()}.
      *
      * @param month  the month (in the range 1 to 12).
      * @param year  the year.
@@ -84,11 +88,13 @@ public class Month extends RegularTimePeriod implements Serializable {
         }
         this.month = month;
         this.year = year;
-        peg(Calendar.getInstance());
+        peg(getCalendarInstance());
     }
 
     /**
      * Constructs a new month instance.
+     * The time zone and locale are determined by the calendar
+     * returned by {@link RegularTimePeriod#getCalendarInstance()}.
      *
      * @param month  the month (in the range 1 to 12).
      * @param year  the year.
@@ -99,19 +105,20 @@ public class Month extends RegularTimePeriod implements Serializable {
         }
         this.month = month;
         this.year = year.getYear();
-        peg(Calendar.getInstance());
+        peg(getCalendarInstance());
     }
 
     /**
-     * Constructs a new {@code Month} instance, based on a date/time and
-     * the default time zone.
+     * Constructs a new {@code Month} instance, based on a date/time.
+     * The time zone and locale are determined by the calendar
+     * returned by {@link RegularTimePeriod#getCalendarInstance()}.
      *
      * @param time  the date/time ({@code null} not permitted).
      *
      * @see #Month(Date, TimeZone, Locale)
      */
     public Month(Date time) {
-        this(time, TimeZone.getDefault(), Locale.getDefault());
+        this(time, getCalendarInstance());
     }
 
     /**
@@ -126,6 +133,21 @@ public class Month extends RegularTimePeriod implements Serializable {
      */
     public Month(Date time, TimeZone zone, Locale locale) {
         Calendar calendar = Calendar.getInstance(zone, locale);
+        calendar.setTime(time);
+        this.month = calendar.get(Calendar.MONTH) + 1;
+        this.year = calendar.get(Calendar.YEAR);
+        peg(calendar);
+    }
+
+    /**
+     * Constructs a new instance, based on a particular date/time.
+     * The time zone and locale are determined by the {@code calendar}
+     * parameter.
+     *
+     * @param time the date/time ({@code null} not permitted).
+     * @param calendar the calendar to use for calculations ({@code null} not permitted).
+     */
+    public Month(Date time, Calendar calendar) {
         calendar.setTime(time);
         this.month = calendar.get(Calendar.MONTH) + 1;
         this.year = calendar.get(Calendar.YEAR);
@@ -205,7 +227,8 @@ public class Month extends RegularTimePeriod implements Serializable {
 
     /**
      * Returns the month preceding this one.  Note that the returned
-     * {@link Month} is "pegged" using the default time-zone, irrespective of
+     * {@link Month} is "pegged" using the default calendar, obtained
+     * with {@link RegularTimePeriod#getCalendarInstance()}, irrespective of
      * the time-zone used to peg of the current month (which is not recorded
      * anywhere).  See the {@link #peg(Calendar)} method.
      *
@@ -230,7 +253,8 @@ public class Month extends RegularTimePeriod implements Serializable {
 
     /**
      * Returns the month following this one.  Note that the returned
-     * {@link Month} is "pegged" using the default time-zone, irrespective of
+     * {@link Month} is "pegged" using the default calendar, obtained
+     * with {@link RegularTimePeriod#getCalendarInstance()}, irrespective of
      * the time-zone used to peg of the current month (which is not recorded
      * anywhere).  See the {@link #peg(Calendar)} method.
      *

--- a/src/main/java/org/jfree/data/time/Quarter.java
+++ b/src/main/java/org/jfree/data/time/Quarter.java
@@ -86,6 +86,8 @@ public class Quarter extends RegularTimePeriod implements Serializable {
 
     /**
      * Constructs a new Quarter, based on the current system date/time.
+     * The time zone and locale are determined by the calendar
+     * returned by {@link RegularTimePeriod#getCalendarInstance()}.
      */
     public Quarter() {
         this(new Date());
@@ -93,6 +95,8 @@ public class Quarter extends RegularTimePeriod implements Serializable {
 
     /**
      * Constructs a new quarter.
+     * The time zone and locale are determined by the calendar
+     * returned by {@link RegularTimePeriod#getCalendarInstance()}.
      *
      * @param year  the year (1900 to 9999).
      * @param quarter  the quarter (1 to 4).
@@ -103,11 +107,13 @@ public class Quarter extends RegularTimePeriod implements Serializable {
         }
         this.year = (short) year;
         this.quarter = (byte) quarter;
-        peg(Calendar.getInstance());
+        peg(getCalendarInstance());
     }
 
     /**
      * Constructs a new quarter.
+     * The time zone and locale are determined by the calendar
+     * returned by {@link RegularTimePeriod#getCalendarInstance()}.
      *
      * @param quarter  the quarter (1 to 4).
      * @param year  the year (1900 to 9999).
@@ -118,19 +124,20 @@ public class Quarter extends RegularTimePeriod implements Serializable {
         }
         this.year = (short) year.getYear();
         this.quarter = (byte) quarter;
-        peg(Calendar.getInstance());
+        peg(getCalendarInstance());
     }
 
     /**
-     * Constructs a new instance, based on a date/time and the default time
-     * zone.
+     * Constructs a new instance, based on a date/time.
+     * The time zone and locale are determined by the calendar
+     * returned by {@link RegularTimePeriod#getCalendarInstance()}.
      *
      * @param time  the date/time ({@code null} not permitted).
      *
      * @see #Quarter(Date, TimeZone, Locale)
      */
     public Quarter(Date time) {
-        this(time, TimeZone.getDefault(), Locale.getDefault());
+        this(time, getCalendarInstance());
     }
 
     /**
@@ -145,6 +152,22 @@ public class Quarter extends RegularTimePeriod implements Serializable {
      */
     public Quarter(Date time, TimeZone zone, Locale locale) {
         Calendar calendar = Calendar.getInstance(zone, locale);
+        calendar.setTime(time);
+        int month = calendar.get(Calendar.MONTH) + 1;
+        this.quarter = (byte) SerialDate.monthCodeToQuarter(month);
+        this.year = (short) calendar.get(Calendar.YEAR);
+        peg(calendar);
+    }
+
+    /**
+     * Constructs a new instance, based on a particular date/time.
+     * The time zone and locale are determined by the {@code calendar}
+     * parameter.
+     *
+     * @param time the date/time ({@code null} not permitted).
+     * @param calendar the calendar to use for calculations ({@code null} not permitted).
+     */
+    public Quarter(Date time, Calendar calendar) {
         calendar.setTime(time);
         int month = calendar.get(Calendar.MONTH) + 1;
         this.quarter = (byte) SerialDate.monthCodeToQuarter(month);
@@ -227,6 +250,9 @@ public class Quarter extends RegularTimePeriod implements Serializable {
 
     /**
      * Returns the quarter preceding this one.
+     * No matter what time zone and locale this instance was created with,
+     * the returned instance will use the default calendar for time
+     * calculations, obtained with {@link RegularTimePeriod#getCalendarInstance()}.
      *
      * @return The quarter preceding this one (or {@code null} if this is
      *     Q1 1900).
@@ -250,6 +276,9 @@ public class Quarter extends RegularTimePeriod implements Serializable {
 
     /**
      * Returns the quarter following this one.
+     * No matter what time zone and locale this instance was created with,
+     * the returned instance will use the default calendar for time
+     * calculations, obtained with {@link RegularTimePeriod#getCalendarInstance()}.
      *
      * @return The quarter following this one (or null if this is Q4 9999).
      */

--- a/src/main/java/org/jfree/data/time/RegularTimePeriod.java
+++ b/src/main/java/org/jfree/data/time/RegularTimePeriod.java
@@ -41,6 +41,8 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
+import java.util.concurrent.atomic.AtomicReference;
+
 import org.jfree.chart.date.MonthConstants;
 
 /**
@@ -53,6 +55,10 @@ import org.jfree.chart.date.MonthConstants;
  */
 public abstract class RegularTimePeriod implements TimePeriod, Comparable,
         MonthConstants {
+
+    private static final AtomicReference<Calendar> calendarPrototype = new AtomicReference<>();
+
+    private static final ThreadLocal<Calendar> threadLocalCalendar = new ThreadLocal<>();
 
     /**
      * Creates a time period that includes the specified millisecond, assuming
@@ -113,6 +119,101 @@ public abstract class RegularTimePeriod implements TimePeriod, Comparable,
         else {
             return Millisecond.class;
         }
+    }
+
+    /**
+     * Creates or returns a thread-local Calendar instance.
+     * This function is used by the various subclasses to obtain a calendar for
+     * date-time to/from ms-since-epoch conversions (and to determine
+     * the first day of the week, in case of {@link Week}).
+     * <p>
+     * If a thread-local calendar was set with {@link #setThreadLocalCalendarInstance(Calendar)},
+     * then it is simply returned.
+     * <p>
+     * Otherwise, If a global calendar prototype was set with {@link #setCalendarInstancePrototype(Calendar)},
+     * then it is cloned and set as the thread-local calendar instance for future use,
+     * as if it was set with {@link #setThreadLocalCalendarInstance(Calendar)}.
+     * <p>
+     * Otherwise, if neither is set, a new instance will be created every
+     * time with {@link Calendar#getInstance()}, resorting to JFreeChart 1.5.0
+     * behavior (leading to huge load on GC and high memory consumption
+     * if many instances are created).
+     *
+     * @return a thread-local Calendar instance
+     */
+    protected static Calendar getCalendarInstance() {
+        Calendar calendar = threadLocalCalendar.get();
+        if (calendar == null) {
+            Calendar prototype = calendarPrototype.get();
+            if (prototype != null) {
+                calendar = (Calendar) prototype.clone();
+                threadLocalCalendar.set(calendar);
+            }
+        }
+        return calendar != null ? calendar : Calendar.getInstance();
+    }
+
+    /**
+     * Sets the thread-local calendar instance for time calculations.
+     * <p>
+     * {@code RegularTimePeriod} instances sometimes need a {@link Calendar}
+     * to perform time calculations (date-time from/to milliseconds-since-epoch).
+     * In JFreeChart 1.5.0, they created a new {@code Calendar} instance
+     * every time they needed one.  This created a huge load on GC and lead
+     * to high memory consumption.  To avoid this, a thread-local {@code Calendar}
+     * instance can be set, which will then be used for time calculations
+     * every time, unless the caller passes a specific {@code Calendar}
+     * instance in places where the API allows it.
+     * <p>
+     * If the specified calendar is {@code null}, or if this method was never called,
+     * then the next time a calendar instance is needed, a new one will be created by cloning
+     * the global prototype set with {@link #setCalendarInstancePrototype(Calendar)}.
+     * If none was set either, then a new instance will be created every time
+     * with {@link Calendar#getInstance()}, resorting to JFreeChart 1.5.0 behavior.
+     *
+     * @param calendar the new thread-local calendar instance
+     */
+    public static void setThreadLocalCalendarInstance(Calendar calendar) {
+        threadLocalCalendar.set(calendar);
+    }
+
+
+    /**
+     * Sets a global calendar prototype for time calculations.
+     * <p>
+     * {@code RegularTimePeriod} instances sometimes need a {@link Calendar}
+     * to perform time calculations (date-time from/to milliseconds-since-epoch).
+     * In JFreeChart 1.5.0, they created a new {@code Calendar} instance
+     * every time they needed one.  This created a huge load on GC and lead
+     * to high memory consumption.  To avoid this, a prototype {@code Calendar}
+     * can be set, which will be then cloned by every thread that needs
+     * a {@code Calendar} instance.  The prototype is not cloned right away,
+     * and stored instead for later cloning, therefore the caller must not
+     * alter the prototype after it has been passed to this method.
+     * <p>
+     * If the prototype is {@code null}, then thread-local calendars
+     * set with {@link #setThreadLocalCalendarInstance(Calendar)} will be
+     * used instead.  If none was set for some thread, then a new instance will be
+     * created with {@link Calendar#getInstance()} every time one is needed.
+     * However, if the prototype was already cloned by some thread,
+     * then setting it to {@code null} has no effect, and that thread must
+     * explicitly set its own instance to {@code null} or something else to get
+     * rid of the cloned calendar.
+     * <p>
+     * Calling {@code setCalendarInstancePrototype(Calendar.getInstance())}
+     * somewhere early in an application will effectively mimic JFreeChart
+     * 1.5.0 behavior (using the default calendar everywhere unless explicitly
+     * specified), while preventing the many-allocations problem.  There is one
+     * important caveat, however: once a prototype is cloned by some
+     * thread, calling {@link TimeZone#setDefault(TimeZone)}
+     * or {@link Locale#setDefault(Locale)}} will have no
+     * effect on future calculations.  To avoid this problem, simply set
+     * the default time zone and locale before setting the prototype.
+     *
+     * @param calendar the new thread-local calendar instance
+     */
+    public static void setCalendarInstancePrototype(Calendar calendar) {
+        calendarPrototype.set(calendar);
     }
 
     /**

--- a/src/main/java/org/jfree/data/time/Second.java
+++ b/src/main/java/org/jfree/data/time/Second.java
@@ -78,6 +78,8 @@ public class Second extends RegularTimePeriod implements Serializable {
 
     /**
      * Constructs a new Second, based on the system date/time.
+     * The time zone and locale are determined by the calendar
+     * returned by {@link RegularTimePeriod#getCalendarInstance()}.
      */
     public Second() {
         this(new Date());
@@ -85,6 +87,8 @@ public class Second extends RegularTimePeriod implements Serializable {
 
     /**
      * Constructs a new Second.
+     * The time zone and locale are determined by the calendar
+     * returned by {@link RegularTimePeriod#getCalendarInstance()}.
      *
      * @param second  the second (0 to 59).
      * @param minute  the minute ({@code null} not permitted).
@@ -97,11 +101,13 @@ public class Second extends RegularTimePeriod implements Serializable {
         this.hour = (byte) minute.getHourValue();
         this.minute = (byte) minute.getMinute();
         this.second = (byte) second;
-        peg(Calendar.getInstance());
+        peg(getCalendarInstance());
     }
 
     /**
      * Creates a new second.
+     * The time zone and locale are determined by the calendar
+     * returned by {@link RegularTimePeriod#getCalendarInstance()}.
      *
      * @param second  the second (0-59).
      * @param minute  the minute (0-59).
@@ -116,15 +122,16 @@ public class Second extends RegularTimePeriod implements Serializable {
     }
 
     /**
-     * Constructs a new instance from the specified date/time and the default
-     * time zone.
+     * Constructs a new instance from the specified date/time.
+     * The time zone and locale are determined by the calendar
+     * returned by {@link RegularTimePeriod#getCalendarInstance()}.
      *
      * @param time  the time ({@code null} not permitted).
      *
      * @see #Second(Date, TimeZone, Locale)
      */
     public Second(Date time) {
-        this(time, TimeZone.getDefault(), Locale.getDefault());
+        this(time, getCalendarInstance());
     }
 
     /**
@@ -137,12 +144,23 @@ public class Second extends RegularTimePeriod implements Serializable {
      * @since 1.0.13
      */
     public Second(Date time, TimeZone zone, Locale locale) {
-        Calendar calendar = Calendar.getInstance(zone, locale);
+        this(time, Calendar.getInstance(zone, locale));
+    }
+
+    /**
+     * Constructs a new instance, based on a particular date/time.
+     * The time zone and locale are determined by the {@code calendar}
+     * parameter.
+     *
+     * @param time the date/time ({@code null} not permitted).
+     * @param calendar the calendar to use for calculations ({@code null} not permitted).
+     */
+    public Second(Date time, Calendar calendar) {
         calendar.setTime(time);
         this.second = (byte) calendar.get(Calendar.SECOND);
         this.minute = (byte) calendar.get(Calendar.MINUTE);
         this.hour = (byte) calendar.get(Calendar.HOUR_OF_DAY);
-        this.day = new Day(time, zone, locale);
+        this.day = new Day(time, calendar);
         peg(calendar);
     }
 
@@ -209,6 +227,9 @@ public class Second extends RegularTimePeriod implements Serializable {
 
     /**
      * Returns the second preceding this one.
+     * No matter what time zone and locale this instance was created with,
+     * the returned instance will use the default calendar for time
+     * calculations, obtained with {@link RegularTimePeriod#getCalendarInstance()}.
      *
      * @return The second preceding this one.
      */
@@ -229,6 +250,9 @@ public class Second extends RegularTimePeriod implements Serializable {
 
     /**
      * Returns the second following this one.
+     * No matter what time zone and locale this instance was created with,
+     * the returned instance will use the default calendar for time
+     * calculations, obtained with {@link RegularTimePeriod#getCalendarInstance()}.
      *
      * @return The second following this one.
      */

--- a/src/main/java/org/jfree/data/time/TimeSeries.java
+++ b/src/main/java/org/jfree/data/time/TimeSeries.java
@@ -343,6 +343,10 @@ public class TimeSeries<S extends Comparable<S>> extends Series<S>
             return null;
         }
         Calendar calendar = Calendar.getInstance(zone);
+        return findValueRange(xRange, xAnchor, calendar);
+    }
+
+    public Range findValueRange(Range xRange, TimePeriodAnchor xAnchor, Calendar calendar) {
         // since the items are ordered, we could be more clever here and avoid
         // iterating over all the data
         double lowY = Double.POSITIVE_INFINITY;

--- a/src/main/java/org/jfree/data/time/TimeSeriesCollection.java
+++ b/src/main/java/org/jfree/data/time/TimeSeriesCollection.java
@@ -631,7 +631,7 @@ public class TimeSeriesCollection<S extends Comparable<S>>
             Comparable seriesKey = (Comparable) visibleSeriesKey;
             TimeSeries<S> series = getSeries((S) seriesKey);
             Range r = series.findValueRange(xRange, this.xPosition,
-                    this.workingCalendar.getTimeZone());
+                    this.workingCalendar);
             result = Range.combineIgnoringNaN(result, r);
         }
         return result;

--- a/src/main/java/org/jfree/data/time/Week.java
+++ b/src/main/java/org/jfree/data/time/Week.java
@@ -79,6 +79,8 @@ public class Week extends RegularTimePeriod implements Serializable {
     /**
      * Creates a new time period for the week in which the current system
      * date/time falls.
+     * The time zone and locale are determined by the calendar
+     * returned by {@link RegularTimePeriod#getCalendarInstance()}.
      */
     public Week() {
         this(new Date());
@@ -86,6 +88,8 @@ public class Week extends RegularTimePeriod implements Serializable {
 
     /**
      * Creates a time period representing the week in the specified year.
+     * The time zone and locale are determined by the calendar
+     * returned by {@link RegularTimePeriod#getCalendarInstance()}.
      *
      * @param week  the week (1 to 53).
      * @param year  the year (1900 to 9999).
@@ -97,11 +101,13 @@ public class Week extends RegularTimePeriod implements Serializable {
         }
         this.week = (byte) week;
         this.year = (short) year;
-        peg(Calendar.getInstance());
+        peg(getCalendarInstance());
     }
 
     /**
      * Creates a time period representing the week in the specified year.
+     * The time zone and locale are determined by the calendar
+     * returned by {@link RegularTimePeriod#getCalendarInstance()}.
      *
      * @param week  the week (1 to 53).
      * @param year  the year (1900 to 9999).
@@ -113,14 +119,17 @@ public class Week extends RegularTimePeriod implements Serializable {
         }
         this.week = (byte) week;
         this.year = (short) year.getYear();
-        peg(Calendar.getInstance());
+        peg(getCalendarInstance());
    }
 
     /**
      * Creates a time period for the week in which the specified date/time
-     * falls, using the default time zone and locale (the locale can affect the
-     * day-of-the-week that marks the beginning of the week, as well as the
-     * minimal number of days in the first week of the year).
+     * falls.
+     * The time zone and locale are determined by the calendar
+     * returned by {@link RegularTimePeriod#getCalendarInstance()}.
+     * The locale can affect the day-of-the-week that marks the beginning
+     * of the week, as well as the minimal number of days in the first week
+     * of the year.
      *
      * @param time  the time ({@code null} not permitted).
      *
@@ -128,7 +137,7 @@ public class Week extends RegularTimePeriod implements Serializable {
      */
     public Week(Date time) {
         // defer argument checking...
-        this(time, TimeZone.getDefault(), Locale.getDefault());
+        this(time, getCalendarInstance());
     }
 
     /**
@@ -146,6 +155,40 @@ public class Week extends RegularTimePeriod implements Serializable {
         Args.nullNotPermitted(zone, "zone");
         Args.nullNotPermitted(locale, "locale");
         Calendar calendar = Calendar.getInstance(zone, locale);
+        calendar.setTime(time);
+
+        // sometimes the last few days of the year are considered to fall in
+        // the *first* week of the following year.  Refer to the Javadocs for
+        // GregorianCalendar.
+        int tempWeek = calendar.get(Calendar.WEEK_OF_YEAR);
+        if (tempWeek == 1
+                && calendar.get(Calendar.MONTH) == Calendar.DECEMBER) {
+            this.week = 1;
+            this.year = (short) (calendar.get(Calendar.YEAR) + 1);
+        }
+        else {
+            this.week = (byte) Math.min(tempWeek, LAST_WEEK_IN_YEAR);
+            int yyyy = calendar.get(Calendar.YEAR);
+            // alternatively, sometimes the first few days of the year are
+            // considered to fall in the *last* week of the previous year...
+            if (calendar.get(Calendar.MONTH) == Calendar.JANUARY
+                    && this.week >= 52) {
+                yyyy--;
+            }
+            this.year = (short) yyyy;
+        }
+        peg(calendar);
+    }
+
+    /**
+     * Constructs a new instance, based on a particular date/time.
+     * The time zone and locale are determined by the {@code calendar}
+     * parameter.
+     *
+     * @param time the date/time ({@code null} not permitted).
+     * @param calendar the calendar to use for calculations ({@code null} not permitted).
+     */
+    public Week(Date time, Calendar calendar) {
         calendar.setTime(time);
 
         // sometimes the last few days of the year are considered to fall in
@@ -230,7 +273,8 @@ public class Week extends RegularTimePeriod implements Serializable {
 
     /**
      * Recalculates the start date/time and end date/time for this time period
-     * relative to the supplied calendar (which incorporates a time zone).
+     * relative to the supplied calendar (which incorporates a time zone
+     * and information about what day is the first day of the week).
      *
      * @param calendar  the calendar ({@code null} not permitted).
      *
@@ -247,6 +291,9 @@ public class Week extends RegularTimePeriod implements Serializable {
      * {@code null} for some lower limit on the range of weeks (currently
      * week 1, 1900).  For week 1 of any year, the previous week is always week
      * 53, but week 53 may not contain any days (you should check for this).
+     * No matter what time zone and locale this instance was created with,
+     * the returned instance will use the default calendar for time
+     * calculations, obtained with {@link RegularTimePeriod#getCalendarInstance()}.
      *
      * @return The preceding week (possibly {@code null}).
      */
@@ -261,7 +308,7 @@ public class Week extends RegularTimePeriod implements Serializable {
             // we need to work out if the previous year has 52 or 53 weeks...
             if (this.year > 1900) {
                 int yy = this.year - 1;
-                Calendar prevYearCalendar = Calendar.getInstance();
+                Calendar prevYearCalendar = getCalendarInstance();
                 prevYearCalendar.set(yy, Calendar.DECEMBER, 31);
                 result = new Week(prevYearCalendar.getActualMaximum(
                         Calendar.WEEK_OF_YEAR), yy);
@@ -280,6 +327,9 @@ public class Week extends RegularTimePeriod implements Serializable {
      * week 53, 9999).  For week 52 of any year, the following week is always
      * week 53, but week 53 may not contain any days (you should check for
      * this).
+     * No matter what time zone and locale this instance was created with,
+     * the returned instance will use the default calendar for time
+     * calculations, obtained with {@link RegularTimePeriod#getCalendarInstance()}.
      *
      * @return The following week (possibly {@code null}).
      */
@@ -291,7 +341,7 @@ public class Week extends RegularTimePeriod implements Serializable {
             result = new Week(this.week + 1, this.year);
         }
         else {
-            Calendar calendar = Calendar.getInstance();
+            Calendar calendar = getCalendarInstance();
             calendar.set(this.year, Calendar.DECEMBER, 31);
             int actualMaxWeek
                 = calendar.getActualMaximum(Calendar.WEEK_OF_YEAR);

--- a/src/main/java/org/jfree/data/time/Year.java
+++ b/src/main/java/org/jfree/data/time/Year.java
@@ -76,6 +76,8 @@ public class Year extends RegularTimePeriod implements Serializable {
 
     /**
      * Creates a new {@code Year}, based on the current system date/time.
+     * The time zone and locale are determined by the calendar
+     * returned by {@link RegularTimePeriod#getCalendarInstance()}.
      */
     public Year() {
         this(new Date());
@@ -83,6 +85,8 @@ public class Year extends RegularTimePeriod implements Serializable {
 
     /**
      * Creates a time period representing a single year.
+     * The time zone and locale are determined by the calendar
+     * returned by {@link RegularTimePeriod#getCalendarInstance()}.
      *
      * @param year  the year.
      */
@@ -92,19 +96,20 @@ public class Year extends RegularTimePeriod implements Serializable {
                 "Year constructor: year (" + year + ") outside valid range.");
         }
         this.year = (short) year;
-        peg(Calendar.getInstance());
+        peg(getCalendarInstance());
     }
 
     /**
-     * Creates a new {@code Year}, based on a particular instant in time,
-     * using the default time zone.
+     * Creates a new {@code Year}, based on a particular instant in time.
+     * The time zone and locale are determined by the calendar
+     * returned by {@link RegularTimePeriod#getCalendarInstance()}.
      *
      * @param time  the time ({@code null} not permitted).
      *
      * @see #Year(Date, TimeZone, Locale)
      */
     public Year(Date time) {
-        this(time, TimeZone.getDefault(), Locale.getDefault());
+        this(time, getCalendarInstance());
     }
 
     /**
@@ -119,6 +124,20 @@ public class Year extends RegularTimePeriod implements Serializable {
      */
     public Year(Date time, TimeZone zone, Locale locale) {
         Calendar calendar = Calendar.getInstance(zone, locale);
+        calendar.setTime(time);
+        this.year = (short) calendar.get(Calendar.YEAR);
+        peg(calendar);
+    }
+
+    /**
+     * Constructs a new instance, based on a particular date/time.
+     * The time zone and locale are determined by the {@code calendar}
+     * parameter.
+     *
+     * @param time the date/time ({@code null} not permitted).
+     * @param calendar the calendar to use for calculations ({@code null} not permitted).
+     */
+    public Year(Date time, Calendar calendar) {
         calendar.setTime(time);
         this.year = (short) calendar.get(Calendar.YEAR);
         peg(calendar);
@@ -179,6 +198,9 @@ public class Year extends RegularTimePeriod implements Serializable {
 
     /**
      * Returns the year preceding this one.
+     * No matter what time zone and locale this instance was created with,
+     * the returned instance will use the default calendar for time
+     * calculations, obtained with {@link RegularTimePeriod#getCalendarInstance()}.
      *
      * @return The year preceding this one (or {@code null} if the
      *         current year is -9999).
@@ -195,6 +217,9 @@ public class Year extends RegularTimePeriod implements Serializable {
 
     /**
      * Returns the year following this one.
+     * No matter what time zone and locale this instance was created with,
+     * the returned instance will use the default calendar for time
+     * calculations, obtained with {@link RegularTimePeriod#getCalendarInstance()}.
      *
      * @return The year following this one (or {@code null} if the current
      *         year is 9999).

--- a/src/test/java/org/jfree/data/time/DayTest.java
+++ b/src/test/java/org/jfree/data/time/DayTest.java
@@ -467,45 +467,46 @@ public class DayTest {
         assertTrue(pass);
     }
 
-    /**
-     * Some checks for the testNext() method.
-     */
     @Test
-    public void testNext() {
+    public void testNextPrevious() {
         Day d = new Day(25, 12, 2000);
         d = (Day) d.next();
         assertEquals(2000, d.getYear());
         assertEquals(12, d.getMonth());
         assertEquals(26, d.getDayOfMonth());
+        d = (Day) d.previous();
+        assertEquals(2000, d.getYear());
+        assertEquals(12, d.getMonth());
+        assertEquals(25, d.getDayOfMonth());
         d = new Day(31, 12, 9999);
         assertNull(d.next());
     }
 
     /**
-     * If a thread-local calendar was set, next() should use its time zone.
+     * If a thread-local calendar was set, next() and previous() should use its time zone.
      */
     @Test
-    public void testNextWithThreadLocalCalendar() {
+    public void testNextPreviousWithThreadLocalCalendar() {
         Consumer<Integer> calendarSetup = hours -> RegularTimePeriod.setThreadLocalCalendarInstance(
                 Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.ofHours(hours)))
         );
-        testNextWithCustomCalendar(3, calendarSetup);
-        testNextWithCustomCalendar(4, calendarSetup);
+        testNextPreviousWithCustomCalendar(3, calendarSetup);
+        testNextPreviousWithCustomCalendar(4, calendarSetup);
     }
 
     /**
      * If a calendar prototype was set, next() should use its time zone.
      */
     @Test
-    public void testNextWithCalendarPrototype() {
+    public void testNextPreviousWithCalendarPrototype() {
         Consumer<Integer> calendarSetup = hours -> RegularTimePeriod.setCalendarInstancePrototype(
                 Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.ofHours(hours)))
         );
-        testNextWithCustomCalendar(3, calendarSetup);
-        testNextWithCustomCalendar(4, calendarSetup);
+        testNextPreviousWithCustomCalendar(3, calendarSetup);
+        testNextPreviousWithCustomCalendar(4, calendarSetup);
     }
 
-    private void testNextWithCustomCalendar(int hoursOffset, Consumer<Integer> calendarSetup) {
+    private void testNextPreviousWithCustomCalendar(int hoursOffset, Consumer<Integer> calendarSetup) {
         try {
             calendarSetup.accept(hoursOffset);
             long ms = 86_400_000L - hoursOffset * 3_600_000L;
@@ -515,6 +516,11 @@ public class DayTest {
             assertEquals(1, d.getMonth());
             assertEquals(3, d.getDayOfMonth());
             assertEquals(ms + 86_400_000L, d.getFirstMillisecond());
+            d = (Day) d.previous();
+            assertEquals(1970, d.getYear());
+            assertEquals(1, d.getMonth());
+            assertEquals(2, d.getDayOfMonth());
+            assertEquals(ms, d.getFirstMillisecond());
         } finally {
             // reset everything, to avoid affecting other tests
             RegularTimePeriod.setThreadLocalCalendarInstance(null);

--- a/src/test/java/org/jfree/data/time/DayTest.java
+++ b/src/test/java/org/jfree/data/time/DayTest.java
@@ -43,16 +43,19 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.ZoneOffset;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.Locale;
 import java.util.TimeZone;
+import java.util.function.Consumer;
 
 import org.jfree.chart.TestUtils;
 import org.jfree.chart.date.MonthConstants;
 
 import org.junit.jupiter.api.Test;
+import org.jfree.chart.date.SerialDate;
 
 /**
  * Tests for the {@link Day} class.
@@ -117,6 +120,124 @@ public class DayTest {
 
         assertEquals(MonthConstants.MARCH, d2.getMonth());
         assertEquals(1078092000000L, d2.getFirstMillisecond(cal));
+    }
+
+    /**
+     * If a thread-local calendar was set, the Date constructor should use it.
+     */
+    @Test
+    public void testDateConstructorWithThreadLocalCalendar() {
+        Consumer<Integer> calendarSetup = hours -> RegularTimePeriod.setThreadLocalCalendarInstance(
+                Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.ofHours(hours)))
+        );
+        testDateConstructorWithCustomCalendar(3, calendarSetup);
+        testDateConstructorWithCustomCalendar(4, calendarSetup);
+    }
+
+    /**
+     * If a calendar prototype was set, the Date constructor should use it.
+     */
+    @Test
+    public void testDateConstructorWithCalendarPrototype() {
+        Consumer<Integer> calendarSetup = hours -> RegularTimePeriod.setCalendarInstancePrototype(
+                Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.ofHours(hours)))
+        );
+        testDateConstructorWithCustomCalendar(3, calendarSetup);
+        testDateConstructorWithCustomCalendar(4, calendarSetup);
+    }
+
+    private void testDateConstructorWithCustomCalendar(int hoursOffset, Consumer<Integer> calendarSetup) {
+        try {
+            calendarSetup.accept(hoursOffset);
+            long ms = 86_400_000L - 3_600_000L * hoursOffset;
+            Day d = new Day(new Date(ms));
+            assertEquals(1970, d.getYear());
+            assertEquals(1, d.getMonth());
+            assertEquals(2, d.getDayOfMonth());
+            assertEquals(ms, d.getFirstMillisecond());
+        } finally {
+            // reset everything, to avoid affecting other tests
+            RegularTimePeriod.setThreadLocalCalendarInstance(null);
+            RegularTimePeriod.setCalendarInstancePrototype(null);
+        }
+    }
+
+    /**
+     * If a thread-local calendar was set, the minute-hour constructor should use it.
+     */
+    @Test
+    public void testDMYConstructorWithThreadLocalCalendar() {
+        Consumer<Integer> calendarSetup = hours -> RegularTimePeriod.setThreadLocalCalendarInstance(
+                Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.ofHours(hours)))
+        );
+        testDMYConstructorWithCustomCalendar(3, calendarSetup);
+        testDMYConstructorWithCustomCalendar(4, calendarSetup);
+    }
+
+    /**
+     * If a calendar prototype was set, the DMY constructor should use it.
+     */
+    @Test
+    public void testDMYConstructorWithCalendarPrototype() {
+        Consumer<Integer> calendarSetup = hours -> RegularTimePeriod.setCalendarInstancePrototype(
+                Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.ofHours(hours)))
+        );
+        testDMYConstructorWithCustomCalendar(3, calendarSetup);
+        testDMYConstructorWithCustomCalendar(4, calendarSetup);
+    }
+
+    private void testDMYConstructorWithCustomCalendar(int hoursOffset, Consumer<Integer> calendarSetup) {
+        try {
+            calendarSetup.accept(hoursOffset);
+            Day d = new Day(1, 1, 1970);
+            assertEquals(1970, d.getYear());
+            assertEquals(1, d.getMonth());
+            assertEquals(1, d.getDayOfMonth());
+            assertEquals(-3_600_000L * hoursOffset, d.getFirstMillisecond());
+        } finally {
+            // reset everything, to avoid affecting other tests
+            RegularTimePeriod.setThreadLocalCalendarInstance(null);
+            RegularTimePeriod.setCalendarInstancePrototype(null);
+        }
+    }
+
+    /**
+     * If a thread-local calendar was set, the SerialDate constructor should use it.
+     */
+    @Test
+    public void testSerialDateConstructorWithThreadLocalCalendar() {
+        Consumer<Integer> calendarSetup = hours -> RegularTimePeriod.setThreadLocalCalendarInstance(
+                Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.ofHours(hours)))
+        );
+        testSerialDateConstructorWithCustomCalendar(3, calendarSetup);
+        testSerialDateConstructorWithCustomCalendar(4, calendarSetup);
+    }
+
+    /**
+     * If a calendar prototype was set, the SerialDate constructor should use it.
+     */
+    @Test
+    public void testSerialDateConstructorWithCalendarPrototype() {
+        Consumer<Integer> calendarSetup = hours -> RegularTimePeriod.setCalendarInstancePrototype(
+                Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.ofHours(hours)))
+        );
+        testSerialDateConstructorWithCustomCalendar(3, calendarSetup);
+        testSerialDateConstructorWithCustomCalendar(4, calendarSetup);
+    }
+
+    private void testSerialDateConstructorWithCustomCalendar(int hoursOffset, Consumer<Integer> calendarSetup) {
+        try {
+            calendarSetup.accept(hoursOffset);
+            Day d = new Day(SerialDate.createInstance(1, 1, 1970));
+            assertEquals(1970, d.getYear());
+            assertEquals(1, d.getMonth());
+            assertEquals(1, d.getDayOfMonth());
+            assertEquals(-3_600_000L * hoursOffset, d.getFirstMillisecond());
+        } finally {
+            // reset everything, to avoid affecting other tests
+            RegularTimePeriod.setThreadLocalCalendarInstance(null);
+            RegularTimePeriod.setCalendarInstancePrototype(null);
+        }
     }
 
     /**
@@ -358,6 +479,47 @@ public class DayTest {
         assertEquals(26, d.getDayOfMonth());
         d = new Day(31, 12, 9999);
         assertNull(d.next());
+    }
+
+    /**
+     * If a thread-local calendar was set, next() should use its time zone.
+     */
+    @Test
+    public void testNextWithThreadLocalCalendar() {
+        Consumer<Integer> calendarSetup = hours -> RegularTimePeriod.setThreadLocalCalendarInstance(
+                Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.ofHours(hours)))
+        );
+        testNextWithCustomCalendar(3, calendarSetup);
+        testNextWithCustomCalendar(4, calendarSetup);
+    }
+
+    /**
+     * If a calendar prototype was set, next() should use its time zone.
+     */
+    @Test
+    public void testNextWithCalendarPrototype() {
+        Consumer<Integer> calendarSetup = hours -> RegularTimePeriod.setCalendarInstancePrototype(
+                Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.ofHours(hours)))
+        );
+        testNextWithCustomCalendar(3, calendarSetup);
+        testNextWithCustomCalendar(4, calendarSetup);
+    }
+
+    private void testNextWithCustomCalendar(int hoursOffset, Consumer<Integer> calendarSetup) {
+        try {
+            calendarSetup.accept(hoursOffset);
+            long ms = 86_400_000L - hoursOffset * 3_600_000L;
+            Day d = new Day(new Date(ms));
+            d = (Day) d.next();
+            assertEquals(1970, d.getYear());
+            assertEquals(1, d.getMonth());
+            assertEquals(3, d.getDayOfMonth());
+            assertEquals(ms + 86_400_000L, d.getFirstMillisecond());
+        } finally {
+            // reset everything, to avoid affecting other tests
+            RegularTimePeriod.setThreadLocalCalendarInstance(null);
+            RegularTimePeriod.setCalendarInstancePrototype(null);
+        }
     }
 
     /**

--- a/src/test/java/org/jfree/data/time/HourTest.java
+++ b/src/test/java/org/jfree/data/time/HourTest.java
@@ -412,46 +412,48 @@ public class HourTest {
         assertEquals(49L, h.getSerialIndex());
     }
 
-    /**
-     * Some checks for the testNext() method.
-     */
     @Test
-    public void testNext() {
+    public void testNextPrevious() {
         Hour h = new Hour(1, 12, 12, 2000);
         h = (Hour) h.next();
         assertEquals(2000, h.getYear());
         assertEquals(12, h.getMonth());
         assertEquals(12, h.getDayOfMonth());
         assertEquals(2, h.getHour());
+        h = (Hour) h.previous();
+        assertEquals(2000, h.getYear());
+        assertEquals(12, h.getMonth());
+        assertEquals(12, h.getDayOfMonth());
+        assertEquals(1, h.getHour());
         h = new Hour(23, 31, 12, 9999);
         assertNull(h.next());
     }
 
     /**
-     * If a thread-local calendar was set, next() should use its time zone.
+     * If a thread-local calendar was set, next() and previous() should use its time zone.
      */
     @Test
-    public void testNextWithThreadLocalCalendar() {
+    public void testNextPreviousWithThreadLocalCalendar() {
         Consumer<Integer> calendarSetup = hours -> RegularTimePeriod.setThreadLocalCalendarInstance(
                 Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.ofHours(hours)))
         );
-        testNextWithCustomCalendar(3, calendarSetup);
-        testNextWithCustomCalendar(4, calendarSetup);
+        testNextPreviousWithCustomCalendar(3, calendarSetup);
+        testNextPreviousWithCustomCalendar(4, calendarSetup);
     }
 
     /**
      * If a calendar prototype was set, next() should use its time zone.
      */
     @Test
-    public void testNextWithCalendarPrototype() {
+    public void testNextPreviousWithCalendarPrototype() {
         Consumer<Integer> calendarSetup = hours -> RegularTimePeriod.setCalendarInstancePrototype(
                 Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.ofHours(hours)))
         );
-        testNextWithCustomCalendar(3, calendarSetup);
-        testNextWithCustomCalendar(4, calendarSetup);
+        testNextPreviousWithCustomCalendar(3, calendarSetup);
+        testNextPreviousWithCustomCalendar(4, calendarSetup);
     }
 
-    private void testNextWithCustomCalendar(int hoursOffset, Consumer<Integer> calendarSetup) {
+    private void testNextPreviousWithCustomCalendar(int hoursOffset, Consumer<Integer> calendarSetup) {
         try {
             calendarSetup.accept(hoursOffset);
             Hour h = new Hour(new Date(0L));
@@ -461,6 +463,12 @@ public class HourTest {
             assertEquals(1, h.getDayOfMonth());
             assertEquals(hoursOffset + 1, h.getHour());
             assertEquals(3_600_000L, h.getFirstMillisecond());
+            h = (Hour) h.previous();
+            assertEquals(1970, h.getYear());
+            assertEquals(1, h.getMonth());
+            assertEquals(1, h.getDayOfMonth());
+            assertEquals(hoursOffset, h.getHour());
+            assertEquals(0L, h.getFirstMillisecond());
         } finally {
             // reset everything, to avoid affecting other tests
             RegularTimePeriod.setThreadLocalCalendarInstance(null);

--- a/src/test/java/org/jfree/data/time/MillisecondTest.java
+++ b/src/test/java/org/jfree/data/time/MillisecondTest.java
@@ -41,11 +41,13 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import java.time.ZoneOffset;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.Locale;
 import java.util.TimeZone;
+import java.util.function.Consumer;
 
 import org.jfree.chart.TestUtils;
 import org.jfree.chart.date.MonthConstants;
@@ -128,6 +130,92 @@ public class MillisecondTest {
 
         assertEquals(123, m2.getMillisecond());
         assertEquals(1016722559123L, m2.getFirstMillisecond(cal));
+    }
+
+    /**
+     * If a thread-local calendar was set, the Date constructor should use it.
+     */
+    @Test
+    public void testDateConstructorWithThreadLocalCalendar() {
+        Consumer<Integer> calendarSetup = hours -> RegularTimePeriod.setThreadLocalCalendarInstance(
+                Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.ofHours(hours)))
+        );
+        testDateConstructorWithCustomCalendar(3, calendarSetup);
+        testDateConstructorWithCustomCalendar(4, calendarSetup);
+    }
+
+    /**
+     * If a calendar prototype was set, the Date constructor should use it.
+     */
+    @Test
+    public void testDateConstructorWithCalendarPrototype() {
+        Consumer<Integer> calendarSetup = hours -> RegularTimePeriod.setCalendarInstancePrototype(
+                Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.ofHours(hours)))
+        );
+        testDateConstructorWithCustomCalendar(3, calendarSetup);
+        testDateConstructorWithCustomCalendar(4, calendarSetup);
+    }
+
+    private void testDateConstructorWithCustomCalendar(int hoursOffset, Consumer<Integer> calendarSetup) {
+        try {
+            calendarSetup.accept(hoursOffset);
+            Millisecond m = new Millisecond(new Date(0L));
+            assertEquals(1970, m.getSecond().getMinute().getHour().getYear());
+            assertEquals(1, m.getSecond().getMinute().getHour().getMonth());
+            assertEquals(1, m.getSecond().getMinute().getHour().getDayOfMonth());
+            assertEquals(hoursOffset, m.getSecond().getMinute().getHour().getHour());
+            assertEquals(0, m.getSecond().getMinute().getMinute());
+            assertEquals(0, m.getSecond().getSecond());
+            assertEquals(0, m.getMillisecond());
+            assertEquals(0L, m.getFirstMillisecond());
+        } finally {
+            // reset everything, to avoid affecting other tests
+            RegularTimePeriod.setThreadLocalCalendarInstance(null);
+            RegularTimePeriod.setCalendarInstancePrototype(null);
+        }
+    }
+
+    /**
+     * If a thread-local calendar was set, the millisecond-second constructor should use it.
+     */
+    @Test
+    public void testMillisecondSecondConstructorWithThreadLocalCalendar() {
+        Consumer<Integer> calendarSetup = hours -> RegularTimePeriod.setThreadLocalCalendarInstance(
+                Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.ofHours(hours)))
+        );
+        testMillisecondSecondConstructorWithCustomCalendar(3, calendarSetup);
+        testMillisecondSecondConstructorWithCustomCalendar(4, calendarSetup);
+    }
+
+    /**
+     * If a calendar prototype was set, the millisecond-second constructor should use it.
+     */
+    @Test
+    public void testMillisecondSecondConstructorWithCalendarPrototype() {
+        Consumer<Integer> calendarSetup = hours -> RegularTimePeriod.setCalendarInstancePrototype(
+                Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.ofHours(hours)))
+        );
+        testMillisecondSecondConstructorWithCustomCalendar(3, calendarSetup);
+        testMillisecondSecondConstructorWithCustomCalendar(4, calendarSetup);
+    }
+
+    private void testMillisecondSecondConstructorWithCustomCalendar(int hoursOffset, Consumer<Integer> calendarSetup) {
+        try {
+            calendarSetup.accept(hoursOffset);
+            Millisecond m = new Millisecond(0, new Second(new Date(0L)));
+            assertEquals(1970, m.getSecond().getMinute().getHour().getYear());
+            assertEquals(1, m.getSecond().getMinute().getHour().getMonth());
+            assertEquals(1, m.getSecond().getMinute().getHour().getDayOfMonth());
+            assertEquals(hoursOffset, m.getSecond().getMinute().getHour().getHour());
+            assertEquals(0, m.getSecond().getMinute().getMinute());
+            assertEquals(0, m.getSecond().getSecond());
+            assertEquals(0, m.getMillisecond());
+            assertEquals(0L, m.getFirstMillisecond());
+        } finally {
+            // reset everything, to avoid affecting other tests
+            RegularTimePeriod.setThreadLocalCalendarInstance(null);
+            RegularTimePeriod.setCalendarInstancePrototype(null);
+        }
     }
 
     /**
@@ -319,6 +407,50 @@ public class MillisecondTest {
         assertEquals(556, m.getMillisecond());
         m = new Millisecond(999, 59, 59, 23, 31, 12, 9999);
         assertNull(m.next());
+    }
+
+    /**
+     * If a thread-local calendar was set, next() should use its time zone.
+     */
+    @Test
+    public void testNextWithThreadLocalCalendar() {
+        Consumer<Integer> calendarSetup = hours -> RegularTimePeriod.setThreadLocalCalendarInstance(
+                Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.ofHours(hours)))
+        );
+        testNextWithCustomCalendar(3, calendarSetup);
+        testNextWithCustomCalendar(4, calendarSetup);
+    }
+
+    /**
+     * If a calendar prototype was set, next() should use its time zone.
+     */
+    @Test
+    public void testNextWithCalendarPrototype() {
+        Consumer<Integer> calendarSetup = hours -> RegularTimePeriod.setCalendarInstancePrototype(
+                Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.ofHours(hours)))
+        );
+        testNextWithCustomCalendar(3, calendarSetup);
+        testNextWithCustomCalendar(4, calendarSetup);
+    }
+
+    private void testNextWithCustomCalendar(int hoursOffset, Consumer<Integer> calendarSetup) {
+        try {
+            calendarSetup.accept(hoursOffset);
+            Millisecond m = new Millisecond(new Date(0L));
+            m = (Millisecond) m.next();
+            assertEquals(1970, m.getSecond().getMinute().getHour().getYear());
+            assertEquals(1, m.getSecond().getMinute().getHour().getMonth());
+            assertEquals(1, m.getSecond().getMinute().getHour().getDayOfMonth());
+            assertEquals(hoursOffset, m.getSecond().getMinute().getHour().getHour());
+            assertEquals(0, m.getSecond().getMinute().getMinute());
+            assertEquals(0, m.getSecond().getSecond());
+            assertEquals(1L, m.getMillisecond());
+            assertEquals(1L, m.getFirstMillisecond());
+        } finally {
+            // reset everything, to avoid affecting other tests
+            RegularTimePeriod.setThreadLocalCalendarInstance(null);
+            RegularTimePeriod.setCalendarInstancePrototype(null);
+        }
     }
 
     /**

--- a/src/test/java/org/jfree/data/time/MillisecondTest.java
+++ b/src/test/java/org/jfree/data/time/MillisecondTest.java
@@ -391,11 +391,8 @@ public class MillisecondTest {
         assertEquals(176461500L, m.getSerialIndex());
     }
 
-    /**
-     * Some checks for the testNext() method.
-     */
     @Test
-    public void testNext() {
+    public void testNextPrevious() {
         Millisecond m = new Millisecond(555, 55, 30, 1, 12, 12, 2000);
         m = (Millisecond) m.next();
         assertEquals(2000, m.getSecond().getMinute().getHour().getYear());
@@ -405,35 +402,43 @@ public class MillisecondTest {
         assertEquals(30, m.getSecond().getMinute().getMinute());
         assertEquals(55, m.getSecond().getSecond());
         assertEquals(556, m.getMillisecond());
+        m = (Millisecond) m.previous();
+        assertEquals(2000, m.getSecond().getMinute().getHour().getYear());
+        assertEquals(12, m.getSecond().getMinute().getHour().getMonth());
+        assertEquals(12, m.getSecond().getMinute().getHour().getDayOfMonth());
+        assertEquals(1, m.getSecond().getMinute().getHour().getHour());
+        assertEquals(30, m.getSecond().getMinute().getMinute());
+        assertEquals(55, m.getSecond().getSecond());
+        assertEquals(555, m.getMillisecond());
         m = new Millisecond(999, 59, 59, 23, 31, 12, 9999);
         assertNull(m.next());
     }
 
     /**
-     * If a thread-local calendar was set, next() should use its time zone.
+     * If a thread-local calendar was set, next() and previous() should use its time zone.
      */
     @Test
-    public void testNextWithThreadLocalCalendar() {
+    public void testNextPreviousWithThreadLocalCalendar() {
         Consumer<Integer> calendarSetup = hours -> RegularTimePeriod.setThreadLocalCalendarInstance(
                 Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.ofHours(hours)))
         );
-        testNextWithCustomCalendar(3, calendarSetup);
-        testNextWithCustomCalendar(4, calendarSetup);
+        testNextPreviousWithCustomCalendar(3, calendarSetup);
+        testNextPreviousWithCustomCalendar(4, calendarSetup);
     }
 
     /**
      * If a calendar prototype was set, next() should use its time zone.
      */
     @Test
-    public void testNextWithCalendarPrototype() {
+    public void testNextPreviousWithCalendarPrototype() {
         Consumer<Integer> calendarSetup = hours -> RegularTimePeriod.setCalendarInstancePrototype(
                 Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.ofHours(hours)))
         );
-        testNextWithCustomCalendar(3, calendarSetup);
-        testNextWithCustomCalendar(4, calendarSetup);
+        testNextPreviousWithCustomCalendar(3, calendarSetup);
+        testNextPreviousWithCustomCalendar(4, calendarSetup);
     }
 
-    private void testNextWithCustomCalendar(int hoursOffset, Consumer<Integer> calendarSetup) {
+    private void testNextPreviousWithCustomCalendar(int hoursOffset, Consumer<Integer> calendarSetup) {
         try {
             calendarSetup.accept(hoursOffset);
             Millisecond m = new Millisecond(new Date(0L));
@@ -446,6 +451,15 @@ public class MillisecondTest {
             assertEquals(0, m.getSecond().getSecond());
             assertEquals(1L, m.getMillisecond());
             assertEquals(1L, m.getFirstMillisecond());
+            m = (Millisecond) m.previous();
+            assertEquals(1970, m.getSecond().getMinute().getHour().getYear());
+            assertEquals(1, m.getSecond().getMinute().getHour().getMonth());
+            assertEquals(1, m.getSecond().getMinute().getHour().getDayOfMonth());
+            assertEquals(hoursOffset, m.getSecond().getMinute().getHour().getHour());
+            assertEquals(0, m.getSecond().getMinute().getMinute());
+            assertEquals(0, m.getSecond().getSecond());
+            assertEquals(0L, m.getMillisecond());
+            assertEquals(0L, m.getFirstMillisecond());
         } finally {
             // reset everything, to avoid affecting other tests
             RegularTimePeriod.setThreadLocalCalendarInstance(null);

--- a/src/test/java/org/jfree/data/time/MinuteTest.java
+++ b/src/test/java/org/jfree/data/time/MinuteTest.java
@@ -41,11 +41,13 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import java.time.ZoneOffset;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.Locale;
 import java.util.TimeZone;
+import java.util.function.Consumer;
 
 import org.jfree.chart.TestUtils;
 import org.jfree.chart.date.MonthConstants;
@@ -119,6 +121,88 @@ public class MinuteTest {
 
         assertEquals(55, m2.getMinute());
         assertEquals(1016700900000L, m2.getFirstMillisecond(cal));
+    }
+
+    /**
+     * If a thread-local calendar was set, the Date constructor should use it.
+     */
+    @Test
+    public void testDateConstructorWithThreadLocalCalendar() {
+        Consumer<Integer> calendarSetup = hours -> RegularTimePeriod.setThreadLocalCalendarInstance(
+                Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.ofHours(hours)))
+        );
+        testDateConstructorWithCustomCalendar(3, calendarSetup);
+        testDateConstructorWithCustomCalendar(4, calendarSetup);
+    }
+
+    /**
+     * If a calendar prototype was set, the Date constructor should use it.
+     */
+    @Test
+    public void testDateConstructorWithCalendarPrototype() {
+        Consumer<Integer> calendarSetup = hours -> RegularTimePeriod.setCalendarInstancePrototype(
+                Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.ofHours(hours)))
+        );
+        testDateConstructorWithCustomCalendar(3, calendarSetup);
+        testDateConstructorWithCustomCalendar(4, calendarSetup);
+    }
+
+    private void testDateConstructorWithCustomCalendar(int hoursOffset, Consumer<Integer> calendarSetup) {
+        try {
+            calendarSetup.accept(hoursOffset);
+            Minute m = new Minute(new Date(0L));
+            assertEquals(1970, m.getHour().getYear());
+            assertEquals(1, m.getHour().getMonth());
+            assertEquals(1, m.getHour().getDayOfMonth());
+            assertEquals(hoursOffset, m.getHour().getHour());
+            assertEquals(0, m.getMinute());
+            assertEquals(0L, m.getFirstMillisecond());
+        } finally {
+            // reset everything, to avoid affecting other tests
+            RegularTimePeriod.setThreadLocalCalendarInstance(null);
+            RegularTimePeriod.setCalendarInstancePrototype(null);
+        }
+    }
+
+    /**
+     * If a thread-local calendar was set, the minute-hour constructor should use it.
+     */
+    @Test
+    public void testMinuteHourConstructorWithThreadLocalCalendar() {
+        Consumer<Integer> calendarSetup = hours -> RegularTimePeriod.setThreadLocalCalendarInstance(
+                Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.ofHours(hours)))
+        );
+        testMinuteHourConstructorWithCustomCalendar(3, calendarSetup);
+        testMinuteHourConstructorWithCustomCalendar(4, calendarSetup);
+    }
+
+    /**
+     * If a calendar prototype was set, the minute-hour constructor should use it.
+     */
+    @Test
+    public void testMinuteHourConstructorWithCalendarPrototype() {
+        Consumer<Integer> calendarSetup = hours -> RegularTimePeriod.setCalendarInstancePrototype(
+                Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.ofHours(hours)))
+        );
+        testMinuteHourConstructorWithCustomCalendar(3, calendarSetup);
+        testMinuteHourConstructorWithCustomCalendar(4, calendarSetup);
+    }
+
+    private void testMinuteHourConstructorWithCustomCalendar(int hoursOffset, Consumer<Integer> calendarSetup) {
+        try {
+            calendarSetup.accept(hoursOffset);
+            Minute m = new Minute(0, new Hour(new Date(0L)));
+            assertEquals(1970, m.getHour().getYear());
+            assertEquals(1, m.getHour().getMonth());
+            assertEquals(1, m.getHour().getDayOfMonth());
+            assertEquals(hoursOffset, m.getHour().getHour());
+            assertEquals(0, m.getMinute());
+            assertEquals(0L, m.getFirstMillisecond());
+        } finally {
+            // reset everything, to avoid affecting other tests
+            RegularTimePeriod.setThreadLocalCalendarInstance(null);
+            RegularTimePeriod.setCalendarInstancePrototype(null);
+        }
     }
 
     /**
@@ -293,6 +377,48 @@ public class MinuteTest {
         assertEquals(31, m.getMinute());
         m = new Minute(59, 23, 31, 12, 9999);
         assertNull(m.next());
+    }
+
+    /**
+     * If a thread-local calendar was set, next() should use its time zone.
+     */
+    @Test
+    public void testNextWithThreadLocalCalendar() {
+        Consumer<Integer> calendarSetup = hours -> RegularTimePeriod.setThreadLocalCalendarInstance(
+                        Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.ofHours(hours)))
+        );
+        testNextWithCustomCalendar(3, calendarSetup);
+        testNextWithCustomCalendar(4, calendarSetup);
+    }
+
+    /**
+     * If a calendar prototype was set, next() should use its time zone.
+     */
+    @Test
+    public void testNextWithCalendarPrototype() {
+        Consumer<Integer> calendarSetup = hours -> RegularTimePeriod.setCalendarInstancePrototype(
+                        Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.ofHours(hours)))
+        );
+        testNextWithCustomCalendar(3, calendarSetup);
+        testNextWithCustomCalendar(4, calendarSetup);
+    }
+
+    private void testNextWithCustomCalendar(int hoursOffset, Consumer<Integer> calendarSetup) {
+        try {
+            calendarSetup.accept(hoursOffset);
+            Minute m = new Minute(new Date(0L));
+            m = (Minute) m.next();
+            assertEquals(1970, m.getHour().getYear());
+            assertEquals(1, m.getHour().getMonth());
+            assertEquals(1, m.getHour().getDayOfMonth());
+            assertEquals(hoursOffset, m.getHour().getHour());
+            assertEquals(1, m.getMinute());
+            assertEquals(60_000L, m.getFirstMillisecond());
+        } finally {
+            // reset everything, to avoid affecting other tests
+            RegularTimePeriod.setThreadLocalCalendarInstance(null);
+            RegularTimePeriod.setCalendarInstancePrototype(null);
+        }
     }
 
     /**

--- a/src/test/java/org/jfree/data/time/MinuteTest.java
+++ b/src/test/java/org/jfree/data/time/MinuteTest.java
@@ -363,9 +363,6 @@ public class MinuteTest {
         assertEquals(2941L, m.getSerialIndex());
     }
 
-    /**
-     * Some checks for the testNext() method.
-     */
     @Test
     public void testNext() {
         Minute m = new Minute(30, 1, 12, 12, 2000);
@@ -375,35 +372,41 @@ public class MinuteTest {
         assertEquals(12, m.getHour().getDayOfMonth());
         assertEquals(1, m.getHour().getHour());
         assertEquals(31, m.getMinute());
+        m = (Minute) m.previous();
+        assertEquals(2000, m.getHour().getYear());
+        assertEquals(12, m.getHour().getMonth());
+        assertEquals(12, m.getHour().getDayOfMonth());
+        assertEquals(1, m.getHour().getHour());
+        assertEquals(30, m.getMinute());
         m = new Minute(59, 23, 31, 12, 9999);
         assertNull(m.next());
     }
 
     /**
-     * If a thread-local calendar was set, next() should use its time zone.
+     * If a thread-local calendar was set, next() and previous() should use its time zone.
      */
     @Test
-    public void testNextWithThreadLocalCalendar() {
+    public void testNextPreviousWithThreadLocalCalendar() {
         Consumer<Integer> calendarSetup = hours -> RegularTimePeriod.setThreadLocalCalendarInstance(
                         Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.ofHours(hours)))
         );
-        testNextWithCustomCalendar(3, calendarSetup);
-        testNextWithCustomCalendar(4, calendarSetup);
+        testNextPreviousWithCustomCalendar(3, calendarSetup);
+        testNextPreviousWithCustomCalendar(4, calendarSetup);
     }
 
     /**
      * If a calendar prototype was set, next() should use its time zone.
      */
     @Test
-    public void testNextWithCalendarPrototype() {
+    public void testNextPreviousWithCalendarPrototype() {
         Consumer<Integer> calendarSetup = hours -> RegularTimePeriod.setCalendarInstancePrototype(
                         Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.ofHours(hours)))
         );
-        testNextWithCustomCalendar(3, calendarSetup);
-        testNextWithCustomCalendar(4, calendarSetup);
+        testNextPreviousWithCustomCalendar(3, calendarSetup);
+        testNextPreviousWithCustomCalendar(4, calendarSetup);
     }
 
-    private void testNextWithCustomCalendar(int hoursOffset, Consumer<Integer> calendarSetup) {
+    private void testNextPreviousWithCustomCalendar(int hoursOffset, Consumer<Integer> calendarSetup) {
         try {
             calendarSetup.accept(hoursOffset);
             Minute m = new Minute(new Date(0L));
@@ -414,6 +417,13 @@ public class MinuteTest {
             assertEquals(hoursOffset, m.getHour().getHour());
             assertEquals(1, m.getMinute());
             assertEquals(60_000L, m.getFirstMillisecond());
+            m = (Minute) m.previous();
+            assertEquals(1970, m.getHour().getYear());
+            assertEquals(1, m.getHour().getMonth());
+            assertEquals(1, m.getHour().getDayOfMonth());
+            assertEquals(hoursOffset, m.getHour().getHour());
+            assertEquals(0, m.getMinute());
+            assertEquals(0L, m.getFirstMillisecond());
         } finally {
             // reset everything, to avoid affecting other tests
             RegularTimePeriod.setThreadLocalCalendarInstance(null);

--- a/src/test/java/org/jfree/data/time/MonthTest.java
+++ b/src/test/java/org/jfree/data/time/MonthTest.java
@@ -41,11 +41,13 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import java.time.ZoneOffset;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.Locale;
 import java.util.TimeZone;
+import java.util.function.Consumer;
 
 import org.jfree.chart.TestUtils;
 import org.jfree.chart.date.MonthConstants;
@@ -141,6 +143,121 @@ public class MonthTest {
         assertEquals(MonthConstants.MARCH, m2.getMonth());
         assertEquals(951822000000L, m2.getFirstMillisecond(cal));
 
+    }
+
+    /**
+     * If a thread-local calendar was set, the Date constructor should use it.
+     */
+    @Test
+    public void testDateConstructorWithThreadLocalCalendar() {
+        Consumer<Integer> calendarSetup = hours -> RegularTimePeriod.setThreadLocalCalendarInstance(
+                Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.ofHours(hours)))
+        );
+        testDateConstructorWithCustomCalendar(3, calendarSetup);
+        testDateConstructorWithCustomCalendar(4, calendarSetup);
+    }
+
+    /**
+     * If a calendar prototype was set, the Date constructor should use it.
+     */
+    @Test
+    public void testDateConstructorWithCalendarPrototype() {
+        Consumer<Integer> calendarSetup = hours -> RegularTimePeriod.setCalendarInstancePrototype(
+                Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.ofHours(hours)))
+        );
+        testDateConstructorWithCustomCalendar(3, calendarSetup);
+        testDateConstructorWithCustomCalendar(4, calendarSetup);
+    }
+
+    private void testDateConstructorWithCustomCalendar(int hoursOffset, Consumer<Integer> calendarSetup) {
+        try {
+            calendarSetup.accept(hoursOffset);
+            long ms = -3_600_000L * hoursOffset;
+            Month m = new Month(new Date(ms));
+            assertEquals(1970, m.getYear().getYear());
+            assertEquals(1, m.getMonth());
+            assertEquals(ms, m.getFirstMillisecond());
+        } finally {
+            // reset everything, to avoid affecting other tests
+            RegularTimePeriod.setThreadLocalCalendarInstance(null);
+            RegularTimePeriod.setCalendarInstancePrototype(null);
+        }
+    }
+
+    /**
+     * If a thread-local calendar was set, the (int, int) month-year constructor should use it.
+     */
+    @Test
+    public void testMonthIntYearConstructorWithThreadLocalCalendar() {
+        Consumer<Integer> calendarSetup = hours -> RegularTimePeriod.setThreadLocalCalendarInstance(
+                Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.ofHours(hours)))
+        );
+        testMonthIntYearConstructorWithCustomCalendar(3, calendarSetup);
+        testMonthIntYearConstructorWithCustomCalendar(4, calendarSetup);
+    }
+
+    /**
+     * If a calendar prototype was set, the the (int, int) month-year constructor should use it.
+     */
+    @Test
+    public void testMonthIntYearConstructorWithCalendarPrototype() {
+        Consumer<Integer> calendarSetup = hours -> RegularTimePeriod.setCalendarInstancePrototype(
+                Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.ofHours(hours)))
+        );
+        testMonthIntYearConstructorWithCustomCalendar(3, calendarSetup);
+        testMonthIntYearConstructorWithCustomCalendar(4, calendarSetup);
+    }
+
+    private void testMonthIntYearConstructorWithCustomCalendar(int hoursOffset, Consumer<Integer> calendarSetup) {
+        try {
+            calendarSetup.accept(hoursOffset);
+            Month m = new Month(1, 1970);
+            assertEquals(1970, m.getYear().getYear());
+            assertEquals(1, m.getMonth());
+            assertEquals(-3_600_000L * hoursOffset, m.getFirstMillisecond());
+        } finally {
+            // reset everything, to avoid affecting other tests
+            RegularTimePeriod.setThreadLocalCalendarInstance(null);
+            RegularTimePeriod.setCalendarInstancePrototype(null);
+        }
+    }
+
+    /**
+     * If a thread-local calendar was set, the (int, Year) month-year constructor should use it.
+     */
+    @Test
+    public void testMonthYearConstructorWithThreadLocalCalendar() {
+        Consumer<Integer> calendarSetup = hours -> RegularTimePeriod.setThreadLocalCalendarInstance(
+                Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.ofHours(hours)))
+        );
+        testMonthYearConstructorWithCustomCalendar(3, calendarSetup);
+        testMonthYearConstructorWithCustomCalendar(4, calendarSetup);
+    }
+
+    /**
+     * If a calendar prototype was set, the the (int, Year) month-year constructor should use it.
+     */
+    @Test
+    public void testMonthYearConstructorWithCalendarPrototype() {
+        Consumer<Integer> calendarSetup = hours -> RegularTimePeriod.setCalendarInstancePrototype(
+                Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.ofHours(hours)))
+        );
+        testMonthYearConstructorWithCustomCalendar(3, calendarSetup);
+        testMonthYearConstructorWithCustomCalendar(4, calendarSetup);
+    }
+
+    private void testMonthYearConstructorWithCustomCalendar(int hoursOffset, Consumer<Integer> calendarSetup) {
+        try {
+            calendarSetup.accept(hoursOffset);
+            Month m = new Month(1, new Year(1970));
+            assertEquals(1970, m.getYear().getYear());
+            assertEquals(1, m.getMonth());
+            assertEquals(-3_600_000L * hoursOffset, m.getFirstMillisecond());
+        } finally {
+            // reset everything, to avoid affecting other tests
+            RegularTimePeriod.setThreadLocalCalendarInstance(null);
+            RegularTimePeriod.setCalendarInstancePrototype(null);
+        }
     }
 
     /**
@@ -391,6 +508,46 @@ public class MonthTest {
         assertEquals(1, m.getMonth());
         m = new Month(12, 9999);
         assertNull(m.next());
+    }
+
+    /**
+     * If a thread-local calendar was set, next() should use its time zone.
+     */
+    @Test
+    public void testNextWithThreadLocalCalendar() {
+        Consumer<Integer> calendarSetup = hours -> RegularTimePeriod.setThreadLocalCalendarInstance(
+                Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.ofHours(hours)))
+        );
+        testNextWithCustomCalendar(3, calendarSetup);
+        testNextWithCustomCalendar(4, calendarSetup);
+    }
+
+    /**
+     * If a calendar prototype was set, next() should use its time zone.
+     */
+    @Test
+    public void testNextWithCalendarPrototype() {
+        Consumer<Integer> calendarSetup = hours -> RegularTimePeriod.setCalendarInstancePrototype(
+                Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.ofHours(hours)))
+        );
+        testNextWithCustomCalendar(3, calendarSetup);
+        testNextWithCustomCalendar(4, calendarSetup);
+    }
+
+    private void testNextWithCustomCalendar(int hoursOffset, Consumer<Integer> calendarSetup) {
+        try {
+            calendarSetup.accept(hoursOffset);
+            long ms = -hoursOffset * 3_600_000L;
+            Month m = new Month(new Date(ms));
+            m = (Month) m.next();
+            assertEquals(1970, m.getYear().getYear());
+            assertEquals(2, m.getMonth());
+            assertEquals(ms + 86_400_000L * 31, m.getFirstMillisecond());
+        } finally {
+            // reset everything, to avoid affecting other tests
+            RegularTimePeriod.setThreadLocalCalendarInstance(null);
+            RegularTimePeriod.setCalendarInstancePrototype(null);
+        }
     }
 
     /**

--- a/src/test/java/org/jfree/data/time/MonthTest.java
+++ b/src/test/java/org/jfree/data/time/MonthTest.java
@@ -497,44 +497,44 @@ public class MonthTest {
         assertEquals(22801L, m.getSerialIndex());
     }
 
-    /**
-     * Some checks for the testNext() method.
-     */
     @Test
-    public void testNext() {
+    public void testNextPrevious() {
         Month m = new Month(12, 2000);
         m = (Month) m.next();
         assertEquals(new Year(2001), m.getYear());
         assertEquals(1, m.getMonth());
+        m = (Month) m.previous();
+        assertEquals(new Year(2000), m.getYear());
+        assertEquals(12, m.getMonth());
         m = new Month(12, 9999);
         assertNull(m.next());
     }
 
     /**
-     * If a thread-local calendar was set, next() should use its time zone.
+     * If a thread-local calendar was set, next() and previous() should use its time zone.
      */
     @Test
-    public void testNextWithThreadLocalCalendar() {
+    public void testNextPreviousWithThreadLocalCalendar() {
         Consumer<Integer> calendarSetup = hours -> RegularTimePeriod.setThreadLocalCalendarInstance(
                 Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.ofHours(hours)))
         );
-        testNextWithCustomCalendar(3, calendarSetup);
-        testNextWithCustomCalendar(4, calendarSetup);
+        testNextPreviousWithCustomCalendar(3, calendarSetup);
+        testNextPreviousWithCustomCalendar(4, calendarSetup);
     }
 
     /**
      * If a calendar prototype was set, next() should use its time zone.
      */
     @Test
-    public void testNextWithCalendarPrototype() {
+    public void testNextPreviousWithCalendarPrototype() {
         Consumer<Integer> calendarSetup = hours -> RegularTimePeriod.setCalendarInstancePrototype(
                 Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.ofHours(hours)))
         );
-        testNextWithCustomCalendar(3, calendarSetup);
-        testNextWithCustomCalendar(4, calendarSetup);
+        testNextPreviousWithCustomCalendar(3, calendarSetup);
+        testNextPreviousWithCustomCalendar(4, calendarSetup);
     }
 
-    private void testNextWithCustomCalendar(int hoursOffset, Consumer<Integer> calendarSetup) {
+    private void testNextPreviousWithCustomCalendar(int hoursOffset, Consumer<Integer> calendarSetup) {
         try {
             calendarSetup.accept(hoursOffset);
             long ms = -hoursOffset * 3_600_000L;
@@ -543,6 +543,10 @@ public class MonthTest {
             assertEquals(1970, m.getYear().getYear());
             assertEquals(2, m.getMonth());
             assertEquals(ms + 86_400_000L * 31, m.getFirstMillisecond());
+            m = (Month) m.previous();
+            assertEquals(1970, m.getYear().getYear());
+            assertEquals(1, m.getMonth());
+            assertEquals(ms, m.getFirstMillisecond());
         } finally {
             // reset everything, to avoid affecting other tests
             RegularTimePeriod.setThreadLocalCalendarInstance(null);

--- a/src/test/java/org/jfree/data/time/QuarterTest.java
+++ b/src/test/java/org/jfree/data/time/QuarterTest.java
@@ -41,11 +41,13 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import java.time.ZoneOffset;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.Locale;
 import java.util.TimeZone;
+import java.util.function.Consumer;
 
 import org.jfree.chart.TestUtils;
 import org.junit.jupiter.api.BeforeEach;
@@ -138,6 +140,121 @@ public class QuarterTest {
         assertEquals(2, q2.getQuarter());
         assertEquals(1017608400000L, q2.getFirstMillisecond(cal));
 
+    }
+
+    /**
+     * If a thread-local calendar was set, the Date constructor should use it.
+     */
+    @Test
+    public void testDateConstructorWithThreadLocalCalendar() {
+        Consumer<Integer> calendarSetup = hours -> RegularTimePeriod.setThreadLocalCalendarInstance(
+                Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.ofHours(hours)))
+        );
+        testDateConstructorWithCustomCalendar(3, calendarSetup);
+        testDateConstructorWithCustomCalendar(4, calendarSetup);
+    }
+
+    /**
+     * If a calendar prototype was set, the Date constructor should use it.
+     */
+    @Test
+    public void testDateConstructorWithCalendarPrototype() {
+        Consumer<Integer> calendarSetup = hours -> RegularTimePeriod.setCalendarInstancePrototype(
+                Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.ofHours(hours)))
+        );
+        testDateConstructorWithCustomCalendar(3, calendarSetup);
+        testDateConstructorWithCustomCalendar(4, calendarSetup);
+    }
+
+    private void testDateConstructorWithCustomCalendar(int hoursOffset, Consumer<Integer> calendarSetup) {
+        try {
+            calendarSetup.accept(hoursOffset);
+            long ms = -3_600_000L * hoursOffset;
+            Quarter q = new Quarter(new Date(ms));
+            assertEquals(1970, q.getYear().getYear());
+            assertEquals(1, q.getQuarter());
+            assertEquals(ms, q.getFirstMillisecond());
+        } finally {
+            // reset everything, to avoid affecting other tests
+            RegularTimePeriod.setThreadLocalCalendarInstance(null);
+            RegularTimePeriod.setCalendarInstancePrototype(null);
+        }
+    }
+
+    /**
+     * If a thread-local calendar was set, the (int, int) quarter-year constructor should use it.
+     */
+    @Test
+    public void testQuarterIntYearConstructorWithThreadLocalCalendar() {
+        Consumer<Integer> calendarSetup = hours -> RegularTimePeriod.setThreadLocalCalendarInstance(
+                Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.ofHours(hours)))
+        );
+        testQuarterIntYearConstructorWithCustomCalendar(3, calendarSetup);
+        testQuarterIntYearConstructorWithCustomCalendar(4, calendarSetup);
+    }
+
+    /**
+     * If a calendar prototype was set, the the (int, int) quarter-year constructor should use it.
+     */
+    @Test
+    public void testQuarterIntYearConstructorWithCalendarPrototype() {
+        Consumer<Integer> calendarSetup = hours -> RegularTimePeriod.setCalendarInstancePrototype(
+                Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.ofHours(hours)))
+        );
+        testQuarterIntYearConstructorWithCustomCalendar(3, calendarSetup);
+        testQuarterIntYearConstructorWithCustomCalendar(4, calendarSetup);
+    }
+
+    private void testQuarterIntYearConstructorWithCustomCalendar(int hoursOffset, Consumer<Integer> calendarSetup) {
+        try {
+            calendarSetup.accept(hoursOffset);
+            Quarter q = new Quarter(1, 1970);
+            assertEquals(1970, q.getYear().getYear());
+            assertEquals(1, q.getQuarter());
+            assertEquals(-3_600_000L * hoursOffset, q.getFirstMillisecond());
+        } finally {
+            // reset everything, to avoid affecting other tests
+            RegularTimePeriod.setThreadLocalCalendarInstance(null);
+            RegularTimePeriod.setCalendarInstancePrototype(null);
+        }
+    }
+
+    /**
+     * If a thread-local calendar was set, the (int, Year) quarter-year constructor should use it.
+     */
+    @Test
+    public void testQuarterYearConstructorWithThreadLocalCalendar() {
+        Consumer<Integer> calendarSetup = hours -> RegularTimePeriod.setThreadLocalCalendarInstance(
+                Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.ofHours(hours)))
+        );
+        testQuarterYearConstructorWithCustomCalendar(3, calendarSetup);
+        testQuarterYearConstructorWithCustomCalendar(4, calendarSetup);
+    }
+
+    /**
+     * If a calendar prototype was set, the the (int, Year) quarter-year constructor should use it.
+     */
+    @Test
+    public void testQuarterYearConstructorWithCalendarPrototype() {
+        Consumer<Integer> calendarSetup = hours -> RegularTimePeriod.setCalendarInstancePrototype(
+                Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.ofHours(hours)))
+        );
+        testQuarterYearConstructorWithCustomCalendar(3, calendarSetup);
+        testQuarterYearConstructorWithCustomCalendar(4, calendarSetup);
+    }
+
+    private void testQuarterYearConstructorWithCustomCalendar(int hoursOffset, Consumer<Integer> calendarSetup) {
+        try {
+            calendarSetup.accept(hoursOffset);
+            Quarter q = new Quarter(1, new Year(1970));
+            assertEquals(1970, q.getYear().getYear());
+            assertEquals(1, q.getQuarter());
+            assertEquals(-3_600_000L * hoursOffset, q.getFirstMillisecond());
+        } finally {
+            // reset everything, to avoid affecting other tests
+            RegularTimePeriod.setThreadLocalCalendarInstance(null);
+            RegularTimePeriod.setCalendarInstancePrototype(null);
+        }
     }
 
     /**
@@ -414,6 +531,46 @@ public class QuarterTest {
         assertEquals(2, q.getQuarter());
         q = new Quarter(4, 9999);
         assertNull(q.next());
+    }
+
+    /**
+     * If a thread-local calendar was set, next() should use its time zone.
+     */
+    @Test
+    public void testNextWithThreadLocalCalendar() {
+        Consumer<Integer> calendarSetup = hours -> RegularTimePeriod.setThreadLocalCalendarInstance(
+                Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.ofHours(hours)))
+        );
+        testNextWithCustomCalendar(3, calendarSetup);
+        testNextWithCustomCalendar(4, calendarSetup);
+    }
+
+    /**
+     * If a calendar prototype was set, next() should use its time zone.
+     */
+    @Test
+    public void testNextWithCalendarPrototype() {
+        Consumer<Integer> calendarSetup = hours -> RegularTimePeriod.setCalendarInstancePrototype(
+                Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.ofHours(hours)))
+        );
+        testNextWithCustomCalendar(3, calendarSetup);
+        testNextWithCustomCalendar(4, calendarSetup);
+    }
+
+    private void testNextWithCustomCalendar(int hoursOffset, Consumer<Integer> calendarSetup) {
+        try {
+            calendarSetup.accept(hoursOffset);
+            long ms = -hoursOffset * 3_600_000L;
+            Quarter q = new Quarter(new Date(ms));
+            q = (Quarter) q.next();
+            assertEquals(1970, q.getYear().getYear());
+            assertEquals(2, q.getQuarter());
+            assertEquals(ms + 86_400_000L * (31 + 28 + 31), q.getFirstMillisecond());
+        } finally {
+            // reset everything, to avoid affecting other tests
+            RegularTimePeriod.setThreadLocalCalendarInstance(null);
+            RegularTimePeriod.setCalendarInstancePrototype(null);
+        }
     }
 
     /**

--- a/src/test/java/org/jfree/data/time/QuarterTest.java
+++ b/src/test/java/org/jfree/data/time/QuarterTest.java
@@ -520,44 +520,44 @@ public class QuarterTest {
         assertEquals(7601L, q.getSerialIndex());
     }
 
-    /**
-     * Some checks for the testNext() method.
-     */
     @Test
-    public void testNext() {
+    public void testNextPrevious() {
         Quarter q = new Quarter(1, 2000);
         q = (Quarter) q.next();
         assertEquals(new Year(2000), q.getYear());
         assertEquals(2, q.getQuarter());
+        q = (Quarter) q.previous();
+        assertEquals(new Year(2000), q.getYear());
+        assertEquals(1, q.getQuarter());
         q = new Quarter(4, 9999);
         assertNull(q.next());
     }
 
     /**
-     * If a thread-local calendar was set, next() should use its time zone.
+     * If a thread-local calendar was set, next() and previous() should use its time zone.
      */
     @Test
-    public void testNextWithThreadLocalCalendar() {
+    public void testNextPreviousWithThreadLocalCalendar() {
         Consumer<Integer> calendarSetup = hours -> RegularTimePeriod.setThreadLocalCalendarInstance(
                 Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.ofHours(hours)))
         );
-        testNextWithCustomCalendar(3, calendarSetup);
-        testNextWithCustomCalendar(4, calendarSetup);
+        testNextPreviousWithCustomCalendar(3, calendarSetup);
+        testNextPreviousWithCustomCalendar(4, calendarSetup);
     }
 
     /**
      * If a calendar prototype was set, next() should use its time zone.
      */
     @Test
-    public void testNextWithCalendarPrototype() {
+    public void testNextPreviousWithCalendarPrototype() {
         Consumer<Integer> calendarSetup = hours -> RegularTimePeriod.setCalendarInstancePrototype(
                 Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.ofHours(hours)))
         );
-        testNextWithCustomCalendar(3, calendarSetup);
-        testNextWithCustomCalendar(4, calendarSetup);
+        testNextPreviousWithCustomCalendar(3, calendarSetup);
+        testNextPreviousWithCustomCalendar(4, calendarSetup);
     }
 
-    private void testNextWithCustomCalendar(int hoursOffset, Consumer<Integer> calendarSetup) {
+    private void testNextPreviousWithCustomCalendar(int hoursOffset, Consumer<Integer> calendarSetup) {
         try {
             calendarSetup.accept(hoursOffset);
             long ms = -hoursOffset * 3_600_000L;
@@ -566,6 +566,10 @@ public class QuarterTest {
             assertEquals(1970, q.getYear().getYear());
             assertEquals(2, q.getQuarter());
             assertEquals(ms + 86_400_000L * (31 + 28 + 31), q.getFirstMillisecond());
+            q = (Quarter) q.previous();
+            assertEquals(1970, q.getYear().getYear());
+            assertEquals(1, q.getQuarter());
+            assertEquals(ms, q.getFirstMillisecond());
         } finally {
             // reset everything, to avoid affecting other tests
             RegularTimePeriod.setThreadLocalCalendarInstance(null);

--- a/src/test/java/org/jfree/data/time/SecondTest.java
+++ b/src/test/java/org/jfree/data/time/SecondTest.java
@@ -366,11 +366,8 @@ public class SecondTest {
         assertEquals(176461L, s.getSerialIndex());
     }
 
-    /**
-     * Some checks for the testNext() method.
-     */
     @Test
-    public void testNext() {
+    public void testNextPrevious() {
         Second s = new Second(55, 30, 1, 12, 12, 2000);
         s = (Second) s.next();
         assertEquals(2000, s.getMinute().getHour().getYear());
@@ -379,35 +376,42 @@ public class SecondTest {
         assertEquals(1, s.getMinute().getHour().getHour());
         assertEquals(30, s.getMinute().getMinute());
         assertEquals(56, s.getSecond());
+        s = (Second) s.previous();
+        assertEquals(2000, s.getMinute().getHour().getYear());
+        assertEquals(12, s.getMinute().getHour().getMonth());
+        assertEquals(12, s.getMinute().getHour().getDayOfMonth());
+        assertEquals(1, s.getMinute().getHour().getHour());
+        assertEquals(30, s.getMinute().getMinute());
+        assertEquals(55, s.getSecond());
         s = new Second(59, 59, 23, 31, 12, 9999);
         assertNull(s.next());
     }
 
     /**
-     * If a thread-local calendar was set, next() should use its time zone.
+     * If a thread-local calendar was set, next() and previous() should use its time zone.
      */
     @Test
-    public void testNextWithThreadLocalCalendar() {
+    public void testNextPreviousWithThreadLocalCalendar() {
         Consumer<Integer> calendarSetup = hours -> RegularTimePeriod.setThreadLocalCalendarInstance(
                 Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.ofHours(hours)))
         );
-        testNextWithCustomCalendar(3, calendarSetup);
-        testNextWithCustomCalendar(4, calendarSetup);
+        testNextPreviousWithCustomCalendar(3, calendarSetup);
+        testNextPreviousWithCustomCalendar(4, calendarSetup);
     }
 
     /**
      * If a calendar prototype was set, next() should use its time zone.
      */
     @Test
-    public void testNextWithCalendarPrototype() {
+    public void testNextPreviousWithCalendarPrototype() {
         Consumer<Integer> calendarSetup = hours -> RegularTimePeriod.setCalendarInstancePrototype(
                 Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.ofHours(hours)))
         );
-        testNextWithCustomCalendar(3, calendarSetup);
-        testNextWithCustomCalendar(4, calendarSetup);
+        testNextPreviousWithCustomCalendar(3, calendarSetup);
+        testNextPreviousWithCustomCalendar(4, calendarSetup);
     }
 
-    private void testNextWithCustomCalendar(int hoursOffset, Consumer<Integer> calendarSetup) {
+    private void testNextPreviousWithCustomCalendar(int hoursOffset, Consumer<Integer> calendarSetup) {
         try {
             calendarSetup.accept(hoursOffset);
             Second s = new Second(new Date(0L));
@@ -419,6 +423,14 @@ public class SecondTest {
             assertEquals(0, s.getMinute().getMinute());
             assertEquals(1, s.getSecond());
             assertEquals(1000L, s.getFirstMillisecond());
+            s = (Second) s.previous();
+            assertEquals(1970, s.getMinute().getHour().getYear());
+            assertEquals(1, s.getMinute().getHour().getMonth());
+            assertEquals(1, s.getMinute().getHour().getDayOfMonth());
+            assertEquals(hoursOffset, s.getMinute().getHour().getHour());
+            assertEquals(0, s.getMinute().getMinute());
+            assertEquals(0, s.getSecond());
+            assertEquals(0L, s.getFirstMillisecond());
         } finally {
             // reset everything, to avoid affecting other tests
             RegularTimePeriod.setThreadLocalCalendarInstance(null);

--- a/src/test/java/org/jfree/data/time/SecondTest.java
+++ b/src/test/java/org/jfree/data/time/SecondTest.java
@@ -41,11 +41,13 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import java.time.ZoneOffset;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.Locale;
 import java.util.TimeZone;
+import java.util.function.Consumer;
 
 import org.jfree.chart.TestUtils;
 import org.jfree.chart.date.MonthConstants;
@@ -120,6 +122,90 @@ public class SecondTest {
 
         assertEquals(59, s2.getSecond());
         assertEquals(1016751359000L, s2.getFirstMillisecond(cal));
+    }
+
+    /**
+     * If a thread-local calendar was set, the Date constructor should use it.
+     */
+    @Test
+    public void testDateConstructorWithThreadLocalCalendar() {
+        Consumer<Integer> calendarSetup = hours -> RegularTimePeriod.setThreadLocalCalendarInstance(
+                Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.ofHours(hours)))
+        );
+        testDateConstructorWithCustomCalendar(3, calendarSetup);
+        testDateConstructorWithCustomCalendar(4, calendarSetup);
+    }
+
+    /**
+     * If a calendar prototype was set, the Date constructor should use it.
+     */
+    @Test
+    public void testDateConstructorWithCalendarPrototype() {
+        Consumer<Integer> calendarSetup = hours -> RegularTimePeriod.setCalendarInstancePrototype(
+                Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.ofHours(hours)))
+        );
+        testDateConstructorWithCustomCalendar(3, calendarSetup);
+        testDateConstructorWithCustomCalendar(4, calendarSetup);
+    }
+
+    private void testDateConstructorWithCustomCalendar(int hoursOffset, Consumer<Integer> calendarSetup) {
+        try {
+            calendarSetup.accept(hoursOffset);
+            Second s = new Second(new Date(0L));
+            assertEquals(1970, s.getMinute().getHour().getYear());
+            assertEquals(1, s.getMinute().getHour().getMonth());
+            assertEquals(1, s.getMinute().getHour().getDayOfMonth());
+            assertEquals(hoursOffset, s.getMinute().getHour().getHour());
+            assertEquals(0, s.getMinute().getMinute());
+            assertEquals(0, s.getSecond());
+            assertEquals(0L, s.getFirstMillisecond());
+        } finally {
+            // reset everything, to avoid affecting other tests
+            RegularTimePeriod.setThreadLocalCalendarInstance(null);
+            RegularTimePeriod.setCalendarInstancePrototype(null);
+        }
+    }
+
+    /**
+     * If a thread-local calendar was set, the second-minute constructor should use it.
+     */
+    @Test
+    public void testSecondMinuteConstructorWithThreadLocalCalendar() {
+        Consumer<Integer> calendarSetup = hours -> RegularTimePeriod.setThreadLocalCalendarInstance(
+                Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.ofHours(hours)))
+        );
+        testSecondMinuteConstructorWithCustomCalendar(3, calendarSetup);
+        testSecondMinuteConstructorWithCustomCalendar(4, calendarSetup);
+    }
+
+    /**
+     * If a calendar prototype was set, the second-minute constructor should use it.
+     */
+    @Test
+    public void testSecondMinuteConstructorWithCalendarPrototype() {
+        Consumer<Integer> calendarSetup = hours -> RegularTimePeriod.setCalendarInstancePrototype(
+                Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.ofHours(hours)))
+        );
+        testSecondMinuteConstructorWithCustomCalendar(3, calendarSetup);
+        testSecondMinuteConstructorWithCustomCalendar(4, calendarSetup);
+    }
+
+    private void testSecondMinuteConstructorWithCustomCalendar(int hoursOffset, Consumer<Integer> calendarSetup) {
+        try {
+            calendarSetup.accept(hoursOffset);
+            Second s = new Second(0, new Minute(new Date(0L)));
+            assertEquals(1970, s.getMinute().getHour().getYear());
+            assertEquals(1, s.getMinute().getHour().getMonth());
+            assertEquals(1, s.getMinute().getHour().getDayOfMonth());
+            assertEquals(hoursOffset, s.getMinute().getHour().getHour());
+            assertEquals(0, s.getMinute().getMinute());
+            assertEquals(0, s.getSecond());
+            assertEquals(0L, s.getFirstMillisecond());
+        } finally {
+            // reset everything, to avoid affecting other tests
+            RegularTimePeriod.setThreadLocalCalendarInstance(null);
+            RegularTimePeriod.setCalendarInstancePrototype(null);
+        }
     }
 
     /**
@@ -295,6 +381,49 @@ public class SecondTest {
         assertEquals(56, s.getSecond());
         s = new Second(59, 59, 23, 31, 12, 9999);
         assertNull(s.next());
+    }
+
+    /**
+     * If a thread-local calendar was set, next() should use its time zone.
+     */
+    @Test
+    public void testNextWithThreadLocalCalendar() {
+        Consumer<Integer> calendarSetup = hours -> RegularTimePeriod.setThreadLocalCalendarInstance(
+                Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.ofHours(hours)))
+        );
+        testNextWithCustomCalendar(3, calendarSetup);
+        testNextWithCustomCalendar(4, calendarSetup);
+    }
+
+    /**
+     * If a calendar prototype was set, next() should use its time zone.
+     */
+    @Test
+    public void testNextWithCalendarPrototype() {
+        Consumer<Integer> calendarSetup = hours -> RegularTimePeriod.setCalendarInstancePrototype(
+                Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.ofHours(hours)))
+        );
+        testNextWithCustomCalendar(3, calendarSetup);
+        testNextWithCustomCalendar(4, calendarSetup);
+    }
+
+    private void testNextWithCustomCalendar(int hoursOffset, Consumer<Integer> calendarSetup) {
+        try {
+            calendarSetup.accept(hoursOffset);
+            Second s = new Second(new Date(0L));
+            s = (Second) s.next();
+            assertEquals(1970, s.getMinute().getHour().getYear());
+            assertEquals(1, s.getMinute().getHour().getMonth());
+            assertEquals(1, s.getMinute().getHour().getDayOfMonth());
+            assertEquals(hoursOffset, s.getMinute().getHour().getHour());
+            assertEquals(0, s.getMinute().getMinute());
+            assertEquals(1, s.getSecond());
+            assertEquals(1000L, s.getFirstMillisecond());
+        } finally {
+            // reset everything, to avoid affecting other tests
+            RegularTimePeriod.setThreadLocalCalendarInstance(null);
+            RegularTimePeriod.setCalendarInstancePrototype(null);
+        }
     }
 
     /**

--- a/src/test/java/org/jfree/data/time/WeekTest.java
+++ b/src/test/java/org/jfree/data/time/WeekTest.java
@@ -41,11 +41,14 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import java.time.ZoneOffset;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.Locale;
 import java.util.TimeZone;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 
 import org.jfree.chart.TestUtils;
 import org.junit.jupiter.api.BeforeEach;
@@ -435,6 +438,50 @@ public class WeekTest {
     }
 
     /**
+     * If a thread-local calendar was set, next() should use its time zone.
+     */
+    @Test
+    public void testNextWithThreadLocalCalendar() {
+        BiConsumer<Integer, String> calendarSetup = (hours, locale) -> RegularTimePeriod.setCalendarInstancePrototype(
+                Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.ofHours(hours)),
+                        Locale.forLanguageTag(locale))
+        );
+        testNextWithCustomCalendar(3, "ru-RU", 4, calendarSetup);
+        testNextWithCustomCalendar(-6, "en-US", 3, calendarSetup);
+    }
+
+    /**
+     * If a calendar prototype was set, next() should use its time zone.
+     */
+    @Test
+    public void testNextWithCalendarPrototype() {
+        BiConsumer<Integer, String> calendarSetup = (hours, locale) -> RegularTimePeriod.setCalendarInstancePrototype(
+                Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.ofHours(hours)),
+                        Locale.forLanguageTag(locale))
+        );
+        testNextWithCustomCalendar(3, "ru-RU", 4, calendarSetup);
+        testNextWithCustomCalendar(-6, "en-US", 3, calendarSetup);
+    }
+
+    private void testNextWithCustomCalendar(int hoursOffset, String locale,
+                                            int secondWeekOffsetInDays,
+                                            BiConsumer<Integer, String> calendarSetup) {
+        try {
+            calendarSetup.accept(hoursOffset, locale);
+            long ms = secondWeekOffsetInDays * 86_400_000L - hoursOffset * 3_600_000L;
+            Week w = new Week(new Date(ms));
+            w = (Week) w.next();
+            assertEquals(1970, w.getYear().getYear());
+            assertEquals(3, w.getWeek());
+            assertEquals(ms + 86_400_000L * 7, w.getFirstMillisecond());
+        } finally {
+            // reset everything, to avoid affecting other tests
+            RegularTimePeriod.setThreadLocalCalendarInstance(null);
+            RegularTimePeriod.setCalendarInstancePrototype(null);
+        }
+    }
+
+    /**
      * Some checks for the getStart() method.
      */
     @Test
@@ -501,6 +548,132 @@ public class WeekTest {
 
         Locale.setDefault(savedLocale);
         TimeZone.setDefault(savedZone);
+    }
+
+    /**
+     * If a thread-local calendar was set, the Date constructor should use it.
+     */
+    @Test
+    public void testDateConstructorWithThreadLocalCalendar() {
+        BiConsumer<Integer, String> calendarSetup = (hours, locale) -> RegularTimePeriod.setCalendarInstancePrototype(
+                Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.ofHours(hours)),
+                        Locale.forLanguageTag(locale))
+        );
+        testDateConstructorWithCustomCalendar(3, "ru-RU", 4, calendarSetup);
+        testDateConstructorWithCustomCalendar(-6, "en-US", 3, calendarSetup);
+    }
+
+    /**
+     * If a calendar prototype was set, the Date constructor should use it.
+     */
+    @Test
+    public void testDateConstructorWithCalendarPrototype() {
+        BiConsumer<Integer, String> calendarSetup = (hours, locale) -> RegularTimePeriod.setCalendarInstancePrototype(
+                Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.ofHours(hours)),
+                        Locale.forLanguageTag(locale))
+        );
+        testDateConstructorWithCustomCalendar(3, "ru-RU", 4, calendarSetup);
+        testDateConstructorWithCustomCalendar(-6, "en-US", 3, calendarSetup);
+    }
+
+    private void testDateConstructorWithCustomCalendar(int hoursOffset, String locale, int secondWeekOffsetInDays,
+                                                       BiConsumer<Integer, String> calendarSetup) {
+        try {
+            calendarSetup.accept(hoursOffset, locale);
+            long ms = secondWeekOffsetInDays * 86_400_000L - 3_600_000L * hoursOffset;
+            Week w = new Week(new Date(ms));
+            assertEquals(1970, w.getYear().getYear());
+            assertEquals(2, w.getWeek());
+            assertEquals(ms, w.getFirstMillisecond());
+        } finally {
+            // reset everything, to avoid affecting other tests
+            RegularTimePeriod.setThreadLocalCalendarInstance(null);
+            RegularTimePeriod.setCalendarInstancePrototype(null);
+        }
+    }
+
+    /**
+     * If a thread-local calendar was set, the (int, int) week-year constructor should use it.
+     */
+    @Test
+    public void testWeekIntYearConstructorWithThreadLocalCalendar() {
+        BiConsumer<Integer, String> calendarSetup = (hours, locale) -> RegularTimePeriod.setCalendarInstancePrototype(
+                Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.ofHours(hours)),
+                        Locale.forLanguageTag(locale))
+        );
+        testWeekIntYearConstructorWithCustomCalendar(3, "ru-RU", 4, calendarSetup);
+        testWeekIntYearConstructorWithCustomCalendar(-6, "en-US", 3, calendarSetup);
+    }
+
+    /**
+     * If a calendar prototype was set, the (int, int) week-year constructor should use it.
+     */
+    @Test
+    public void testWeekIntYearConstructorWithCalendarPrototype() {
+        BiConsumer<Integer, String> calendarSetup = (hours, locale) -> RegularTimePeriod.setCalendarInstancePrototype(
+                Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.ofHours(hours)),
+                        Locale.forLanguageTag(locale))
+        );
+        testWeekIntYearConstructorWithCustomCalendar(3, "ru-RU", 4, calendarSetup);
+        testWeekIntYearConstructorWithCustomCalendar(-6, "en-US", 3, calendarSetup);
+    }
+
+    private void testWeekIntYearConstructorWithCustomCalendar(int hoursOffset, String locale, int secondWeekOffsetInDays,
+                                                       BiConsumer<Integer, String> calendarSetup) {
+        try {
+            calendarSetup.accept(hoursOffset, locale);
+            long ms = secondWeekOffsetInDays * 86_400_000L - 3_600_000L * hoursOffset;
+            Week w = new Week(2, 1970);
+            assertEquals(1970, w.getYear().getYear());
+            assertEquals(2, w.getWeek());
+            assertEquals(ms, w.getFirstMillisecond());
+        } finally {
+            // reset everything, to avoid affecting other tests
+            RegularTimePeriod.setThreadLocalCalendarInstance(null);
+            RegularTimePeriod.setCalendarInstancePrototype(null);
+        }
+    }
+
+    /**
+     * If a thread-local calendar was set, the (int, Year) week-year constructor should use it.
+     */
+    @Test
+    public void testWeekYearConstructorWithThreadLocalCalendar() {
+        BiConsumer<Integer, String> calendarSetup = (hours, locale) -> RegularTimePeriod.setCalendarInstancePrototype(
+                Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.ofHours(hours)),
+                        Locale.forLanguageTag(locale))
+        );
+        testWeekYearConstructorWithCustomCalendar(3, "ru-RU", 4, calendarSetup);
+        testWeekYearConstructorWithCustomCalendar(-6, "en-US", 3, calendarSetup);
+    }
+
+    /**
+     * If a calendar prototype was set, the (int, Year) week-year constructor should use it.
+     */
+    @Test
+    public void testWeekYearConstructorWithCalendarPrototype() {
+        BiConsumer<Integer, String> calendarSetup = (hours, locale) -> RegularTimePeriod.setCalendarInstancePrototype(
+                Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.ofHours(hours)),
+                        Locale.forLanguageTag(locale))
+        );
+        testWeekYearConstructorWithCustomCalendar(3, "ru-RU", 4, calendarSetup);
+        testWeekYearConstructorWithCustomCalendar(-6, "en-US", 3, calendarSetup);
+    }
+
+    private void testWeekYearConstructorWithCustomCalendar(int hoursOffset, String locale, int secondWeekOffsetInDays,
+                                                       BiConsumer<Integer, String> calendarSetup) {
+        try {
+            calendarSetup.accept(hoursOffset, locale);
+            long ms = secondWeekOffsetInDays * 86_400_000L - 3_600_000L * hoursOffset;
+            Week w = new Week(2, new Year(1970));
+            assertEquals(1970, w.getYear().getYear());
+            assertEquals(2, w.getWeek());
+            assertEquals(ms, w.getFirstMillisecond());
+        } finally {
+            // reset everything, to avoid affecting other tests
+            RegularTimePeriod.setThreadLocalCalendarInstance(null);
+            RegularTimePeriod.setCalendarInstancePrototype(null);
+        }
     }
 
     @Test

--- a/src/test/java/org/jfree/data/time/WeekTest.java
+++ b/src/test/java/org/jfree/data/time/WeekTest.java
@@ -428,42 +428,45 @@ public class WeekTest {
      * Some checks for the testNext() method.
      */
     @Test
-    public void testNext() {
+    public void testNextPrevious() {
         Week w = new Week(12, 2000);
         w = (Week) w.next();
         assertEquals(new Year(2000), w.getYear());
         assertEquals(13, w.getWeek());
+        w = (Week) w.previous();
+        assertEquals(new Year(2000), w.getYear());
+        assertEquals(12, w.getWeek());
         w = new Week(53, 9999);
         assertNull(w.next());
     }
 
     /**
-     * If a thread-local calendar was set, next() should use its time zone.
+     * If a thread-local calendar was set, next() and previous() should use its time zone.
      */
     @Test
-    public void testNextWithThreadLocalCalendar() {
+    public void testNextPreviousWithThreadLocalCalendar() {
         BiConsumer<Integer, String> calendarSetup = (hours, locale) -> RegularTimePeriod.setCalendarInstancePrototype(
                 Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.ofHours(hours)),
                         Locale.forLanguageTag(locale))
         );
-        testNextWithCustomCalendar(3, "ru-RU", 4, calendarSetup);
-        testNextWithCustomCalendar(-6, "en-US", 3, calendarSetup);
+        testNextPreviousWithCustomCalendar(3, "ru-RU", 4, calendarSetup);
+        testNextPreviousWithCustomCalendar(-6, "en-US", 3, calendarSetup);
     }
 
     /**
      * If a calendar prototype was set, next() should use its time zone.
      */
     @Test
-    public void testNextWithCalendarPrototype() {
+    public void testNextPreviousWithCalendarPrototype() {
         BiConsumer<Integer, String> calendarSetup = (hours, locale) -> RegularTimePeriod.setCalendarInstancePrototype(
                 Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.ofHours(hours)),
                         Locale.forLanguageTag(locale))
         );
-        testNextWithCustomCalendar(3, "ru-RU", 4, calendarSetup);
-        testNextWithCustomCalendar(-6, "en-US", 3, calendarSetup);
+        testNextPreviousWithCustomCalendar(3, "ru-RU", 4, calendarSetup);
+        testNextPreviousWithCustomCalendar(-6, "en-US", 3, calendarSetup);
     }
 
-    private void testNextWithCustomCalendar(int hoursOffset, String locale,
+    private void testNextPreviousWithCustomCalendar(int hoursOffset, String locale,
                                             int secondWeekOffsetInDays,
                                             BiConsumer<Integer, String> calendarSetup) {
         try {
@@ -474,6 +477,10 @@ public class WeekTest {
             assertEquals(1970, w.getYear().getYear());
             assertEquals(3, w.getWeek());
             assertEquals(ms + 86_400_000L * 7, w.getFirstMillisecond());
+            w = (Week) w.previous();
+            assertEquals(1970, w.getYear().getYear());
+            assertEquals(2, w.getWeek());
+            assertEquals(ms, w.getFirstMillisecond());
         } finally {
             // reset everything, to avoid affecting other tests
             RegularTimePeriod.setThreadLocalCalendarInstance(null);

--- a/src/test/java/org/jfree/data/time/YearTest.java
+++ b/src/test/java/org/jfree/data/time/YearTest.java
@@ -437,43 +437,42 @@ public class YearTest {
         assertEquals(2000L, y.getSerialIndex());
     }
 
-    /**
-     * Some checks for the testNext() method.
-     */
     @Test
     public void testNext() {
         Year y = new Year(2000);
         y = (Year) y.next();
         assertEquals(2001, y.getYear());
+        y = (Year) y.previous();
+        assertEquals(2000, y.getYear());
         y = new Year(9999);
         assertNull(y.next());
     }
 
     /**
-     * If a thread-local calendar was set, next() should use its time zone.
+     * If a thread-local calendar was set, next() and previous() should use its time zone.
      */
     @Test
-    public void testNextWithThreadLocalCalendar() {
+    public void testNextPreviousWithThreadLocalCalendar() {
         Consumer<Integer> calendarSetup = hours -> RegularTimePeriod.setThreadLocalCalendarInstance(
                 Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.ofHours(hours)))
         );
-        testNextWithCustomCalendar(3, calendarSetup);
-        testNextWithCustomCalendar(4, calendarSetup);
+        testNextPreviousWithCustomCalendar(3, calendarSetup);
+        testNextPreviousWithCustomCalendar(4, calendarSetup);
     }
 
     /**
      * If a calendar prototype was set, next() should use its time zone.
      */
     @Test
-    public void testNextWithCalendarPrototype() {
+    public void testNextPreviousWithCalendarPrototype() {
         Consumer<Integer> calendarSetup = hours -> RegularTimePeriod.setCalendarInstancePrototype(
                 Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.ofHours(hours)))
         );
-        testNextWithCustomCalendar(3, calendarSetup);
-        testNextWithCustomCalendar(4, calendarSetup);
+        testNextPreviousWithCustomCalendar(3, calendarSetup);
+        testNextPreviousWithCustomCalendar(4, calendarSetup);
     }
 
-    private void testNextWithCustomCalendar(int hoursOffset, Consumer<Integer> calendarSetup) {
+    private void testNextPreviousWithCustomCalendar(int hoursOffset, Consumer<Integer> calendarSetup) {
         try {
             calendarSetup.accept(hoursOffset);
             long ms = -hoursOffset * 3_600_000L;
@@ -481,6 +480,9 @@ public class YearTest {
             y = (Year) y.next();
             assertEquals(1971, y.getYear());
             assertEquals(ms + 86_400_000L * 365, y.getFirstMillisecond());
+            y = (Year) y.previous();
+            assertEquals(1970, y.getYear());
+            assertEquals(ms, y.getFirstMillisecond());
         } finally {
             // reset everything, to avoid affecting other tests
             RegularTimePeriod.setThreadLocalCalendarInstance(null);


### PR DESCRIPTION
In JFreeChart 1.5.0, `RegularTimePeriod` subclasses create a new calendar instance every time they need one, which is during every construction, including via `next()` and `previous()` methods. In most setups, this creates a new `GregorianCalendar` instance, which is very heavyweight (at least two arrays of `int` and one array of `boolean`, 17 elements each). For example, when creating and displaying a chart for 86400 seconds (one day's worth), this doubles memory consumption (200–250 MB instead of slightly above 100). The GC simply can't cope fast enough with this.

Since the calendars are only used temporarily for time calculations (“pegging”) and then immediately discarded, it would make sense to use a single global instance. However, since `Calendar` is mutable, it would create concurrency problems with multi-threaded applications. It's not a problem for displaying a single chart with Swing, but could be a problem for an application that performs some kind of batch processing, producing a lot of charts for a lot of input files. Therefore, it makes sense to make those calendars thread-local.

This PR introduces three methods:

- `RegularTimePeriod.setThreadLocalCalendarInstance()`—a public method that allows every thread to set a thread-local calendar for every future `RegularTimePeriod` creation (except with constructors that accept a time zone or a calendar explicitly).
- `RegularTimePeriod.setCalendarInstancePrototype()`—a public method that allows to set a global prototype (as in the Prototype Pattern) instance that will be then cloned by every thread as needed and cached locally as if it was set with `setThreadLocalCalendarInstance()`.
-`RegularTimePeriod.getCalendarInstance()`—a protected method that is now used by all `RegularTimePeriod` subclasses where `Calendar.getInstance()` was used previously. If none of the `set*()` methods are called, this method resorts to JFreeChart 1.5.0 behavior, spamming a new instance every time one is needed, which means users that don't call the new `set*()` methods won't be affected in any way.

Constructors accepting a `Calendar` explicitly were added as well. This lead to some code duplication between `(..., TimeZone, Locale)` and the new `(..., Calendar)` constructors. It can be fixed by either generifying `Args.nullNotPermitted()` to return the first argument (much like `Objects.requireNonNull()` does), or by switching to `Objects.requireNonNull()` (which would change the exception type from `IllegalArgumentException` to `NullPointerException`). Please let me know if that's desirable, so I can add another commit to this PR.