### PR TITLE
Backport f19cea1ef6daccda17b9999264481c5b517861d8.

### DIFF
--- a/src/test/java/org/jfree/data/time/TimeSeriesCollectionTest.java
+++ b/src/test/java/org/jfree/data/time/TimeSeriesCollectionTest.java
@@ -32,14 +32,6 @@
  * Original Author:  David Gilbert (for Object Refinery Limited);
  * Contributor(s):   -;
  *
- * Changes
- * -------
- * 01-May-2003 : Version 1 (DG);
- * 04-Dec-2003 : Added a test for the getSurroundingItems() method (DG);
- * 08-May-2007 : Added testIndexOf() method (DG);
- * 18-May-2009 : Added testFindDomainBounds() (DG);
- * 08-Jan-2012 : Added testBug3445507() (DG);
- *
  */
 
 package org.jfree.data.time;
@@ -58,7 +50,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.TimeZone;
 import org.jfree.chart.TestUtils;
-
 import org.jfree.data.Range;
 import org.jfree.data.general.DatasetUtils;
 import org.junit.jupiter.api.Test;
@@ -309,6 +300,10 @@ public class TimeSeriesCollectionTest {
      */
     @Test
     public void testFindDomainBounds() {
+        // store the current time zone
+        TimeZone saved = TimeZone.getDefault();
+        TimeZone.setDefault(TimeZone.getTimeZone("Europe/Paris"));
+
         TimeSeriesCollection dataset = new TimeSeriesCollection();
         List<String> visibleSeriesKeys = new ArrayList<>();
         Range r = DatasetUtils.findDomainBounds(dataset, visibleSeriesKeys,
@@ -320,10 +315,6 @@ public class TimeSeriesCollectionTest {
         visibleSeriesKeys.add("S1");
         r = DatasetUtils.findDomainBounds(dataset, visibleSeriesKeys, true);
         assertNull(r);
-
-        // store the current time zone
-        TimeZone saved = TimeZone.getDefault();
-        TimeZone.setDefault(TimeZone.getTimeZone("Europe/Paris"));
 
         s1.add(new Year(2008), 8.0);
         r = DatasetUtils.findDomainBounds(dataset, visibleSeriesKeys, true);


### PR DESCRIPTION
As suggested in [issue #114](https://github.com/jfree/jfreechart/issues/114), the problem is fixed [here](https://github.com/jfree/jfreechart/commit/f19cea1ef6daccda17b9999264481c5b517861d8#diff-84fcd834bcd20e78a9936d4b82586186L310). This `backport` branch of `v1.5.x` used `git cherry-pick` to allow the test to pass. Tested in GMT-4.