### PR TITLE
Fixed Localization String ('Save_as' without '...')

### DIFF
--- a/src/main/java/org/jfree/chart/ChartPanel.java
+++ b/src/main/java/org/jfree/chart/ChartPanel.java
@@ -2839,7 +2839,7 @@ public class ChartPanel extends JPanel implements ChartChangeListener,
                 result.addSeparator();
             }
             
-            JMenu saveSubMenu = new JMenu(localizationResources.getString("Save_as"));
+            JMenu saveSubMenu = new JMenu(localizationResources.getString("Save_as..."));
             
             // PNG - current res
             {


### PR DESCRIPTION
the 'Save_as' localization string was missing the suffix '...', causing the string not to be translated