### PR TITLE
Fix subpixel text anti-aliasing

### DIFF
--- a/src/main/java/org/jfree/chart/ChartPanel.java
+++ b/src/main/java/org/jfree/chart/ChartPanel.java
@@ -1370,8 +1370,7 @@ public class ChartPanel extends JPanel implements ChartChangeListener,
                 this.chartBufferHeight = scaledHeight;
                 GraphicsConfiguration gc = g2.getDeviceConfiguration();
                 this.chartBuffer = gc.createCompatibleImage(
-                        this.chartBufferWidth, this.chartBufferHeight,
-                        Transparency.TRANSLUCENT);
+                        this.chartBufferWidth, this.chartBufferHeight);
                 this.refreshBuffer = true;
             }
 


### PR DESCRIPTION
Hi,

I noticed that subpixel text anti-aliasing doesn't work when the hint is set on the chart:

    chart.setTextAntiAlias(RenderingHints.VALUE_TEXT_ANTIALIAS_LCD_HRGB);

With this hint the title and the values on the axis are anti-aliased with shades of gray and look blurry.

A workaround is to disable the buffering of the ChartPanel.

Another solution is to remove the `Transparency.TRANSLUCENT` parameter when creating the buffer, this is what this PR suggests.
