### PR TITLE
Do not draw the disabled outline of horizontal crosshair's labels

### DIFF
--- a/src/main/java/org/jfree/chart/panel/CrosshairOverlay.java
+++ b/src/main/java/org/jfree/chart/panel/CrosshairOverlay.java
@@ -305,8 +305,8 @@ public class CrosshairOverlay extends AbstractOverlay implements Overlay,
                 if (crosshair.isLabelOutlineVisible()) {
                     g2.setPaint(crosshair.getLabelOutlinePaint());
                     g2.setStroke(crosshair.getLabelOutlineStroke());
+                    g2.draw(hotspot);
                 }
-                g2.draw(hotspot);
                 g2.setPaint(crosshair.getLabelPaint());
                 TextUtils.drawAlignedString(label, g2, xx, yy, alignPt);
                 g2.setFont(savedFont);


### PR DESCRIPTION
The outline of the label attached to an horizontal crosshair is drawn even if the outline is disabled. This PR aligns the code painting the horizontal crosshair with the code for the vertical crosshair which is correct.