### PR TITLE
Apply the offset to the crosshair labels

### DIFF
--- a/src/main/java/org/jfree/chart/panel/CrosshairOverlay.java
+++ b/src/main/java/org/jfree/chart/panel/CrosshairOverlay.java
@@ -284,7 +284,7 @@ public class CrosshairOverlay extends AbstractOverlay implements Overlay,
                 String label = crosshair.getLabelGenerator().generateLabel(
                         crosshair);
                 RectangleAnchor anchor = crosshair.getLabelAnchor();
-                Point2D pt = calculateLabelPoint(line, anchor, 5, 5);
+                Point2D pt = calculateLabelPoint(line, anchor, crosshair.getLabelXOffset(), crosshair.getLabelYOffset());
                 float xx = (float) pt.getX();
                 float yy = (float) pt.getY();
                 TextAnchor alignPt = textAlignPtForLabelAnchorH(anchor);
@@ -292,7 +292,7 @@ public class CrosshairOverlay extends AbstractOverlay implements Overlay,
                         label, g2, xx, yy, alignPt, 0.0, TextAnchor.CENTER);
                 if (!dataArea.contains(hotspot.getBounds2D())) {
                     anchor = flipAnchorV(anchor);
-                    pt = calculateLabelPoint(line, anchor, 5, 5);
+                    pt = calculateLabelPoint(line, anchor, crosshair.getLabelXOffset(), crosshair.getLabelYOffset());
                     xx = (float) pt.getX();
                     yy = (float) pt.getY();
                     alignPt = textAlignPtForLabelAnchorH(anchor);
@@ -341,7 +341,7 @@ public class CrosshairOverlay extends AbstractOverlay implements Overlay,
                 String label = crosshair.getLabelGenerator().generateLabel(
                         crosshair);
                 RectangleAnchor anchor = crosshair.getLabelAnchor();
-                Point2D pt = calculateLabelPoint(line, anchor, 5, 5);
+                Point2D pt = calculateLabelPoint(line, anchor, crosshair.getLabelXOffset(), crosshair.getLabelYOffset());
                 float xx = (float) pt.getX();
                 float yy = (float) pt.getY();
                 TextAnchor alignPt = textAlignPtForLabelAnchorV(anchor);
@@ -349,7 +349,7 @@ public class CrosshairOverlay extends AbstractOverlay implements Overlay,
                         label, g2, xx, yy, alignPt, 0.0, TextAnchor.CENTER);
                 if (!dataArea.contains(hotspot.getBounds2D())) {
                     anchor = flipAnchorH(anchor);
-                    pt = calculateLabelPoint(line, anchor, 5, 5);
+                    pt = calculateLabelPoint(line, anchor, crosshair.getLabelXOffset(), crosshair.getLabelYOffset());
                     xx = (float) pt.getX();
                     yy = (float) pt.getY();
                     alignPt = textAlignPtForLabelAnchorV(anchor);

--- a/src/main/java/org/jfree/chart/plot/Crosshair.java
+++ b/src/main/java/org/jfree/chart/plot/Crosshair.java
@@ -170,8 +170,8 @@ public class Crosshair implements Cloneable, PublicCloneable, Serializable {
         this.labelVisible = false;
         this.labelGenerator = new StandardCrosshairLabelGenerator();
         this.labelAnchor = RectangleAnchor.BOTTOM_LEFT;
-        this.labelXOffset = 3.0;
-        this.labelYOffset = 3.0;
+        this.labelXOffset = 5.0;
+        this.labelYOffset = 5.0;
         this.labelFont = new Font("Tahoma", Font.PLAIN, 12);
         this.labelPaint = Color.BLACK;
         this.labelBackgroundPaint = new Color(0, 0, 255, 63);


### PR DESCRIPTION
The crosshair has a label offset but it's never used in the code, the paint methods in CrosshairOverlay always apply a hard coded offset of 5 pixels. This PR ensures that the offset defined for the crosshair is really used during the painting.