### PR TITLE
CandlestickRenderer draws better candles

### DIFF
--- a/src/main/java/org/jfree/chart/renderer/xy/CandlestickRenderer.java
+++ b/src/main/java/org/jfree/chart/renderer/xy/CandlestickRenderer.java
@@ -633,7 +633,19 @@ public class CandlestickRenderer extends AbstractXYItemRenderer
         double yyLow = rangeAxis.valueToJava2D(yLow, dataArea, edge);
         double yyOpen = rangeAxis.valueToJava2D(yOpen, dataArea, edge);
         double yyClose = rangeAxis.valueToJava2D(yClose, dataArea, edge);
-
+        Paint p = getItemPaint(series, item);
+        Paint outlinePaint = null;
+        if (this.useOutlinePaint) {
+            outlinePaint = getItemOutlinePaint(series, item);
+        }
+        Stroke s = getItemStroke(series, item);
+        g2.setStroke(s);
+        if (this.useOutlinePaint) {
+            g2.setPaint(outlinePaint);
+        }
+        else {
+            g2.setPaint(p);
+        }
         double volumeWidth;
         double stickWidth;
         if (this.candleWidth > 0) {
@@ -693,16 +705,6 @@ public class CandlestickRenderer extends AbstractXYItemRenderer
             volumeWidth = Math.max(Math.min(1, this.maxCandleWidth), xxWidth);
             stickWidth = Math.max(Math.min(3, this.maxCandleWidth), xxWidth);
         }
-
-        Paint p = getItemPaint(series, item);
-        Paint outlinePaint = null;
-        if (this.useOutlinePaint) {
-            outlinePaint = getItemOutlinePaint(series, item);
-        }
-        Stroke s = getItemStroke(series, item);
-
-        g2.setStroke(s);
-
         if (this.drawVolume) {
             int volume = (int) highLowData.getVolumeValue(series, item);
             double volumeHeight = volume / this.maxVolume;
@@ -735,14 +737,6 @@ public class CandlestickRenderer extends AbstractXYItemRenderer
 
             g2.setComposite(originalComposite);
         }
-
-        if (this.useOutlinePaint) {
-            g2.setPaint(outlinePaint);
-        }
-        else {
-            g2.setPaint(p);
-        }
-
         double yyMaxOpenClose = Math.max(yyOpen, yyClose);
         double yyMinOpenClose = Math.min(yyOpen, yyClose);
         double maxOpenClose = Math.max(yOpen, yClose);
@@ -792,7 +786,6 @@ public class CandlestickRenderer extends AbstractXYItemRenderer
             else {
                 g2.setPaint(p);
             }
-            g2.fill(body);
         }
         else {
             if (this.downPaint != null) {
@@ -801,14 +794,8 @@ public class CandlestickRenderer extends AbstractXYItemRenderer
             else {
                 g2.setPaint(p);
             }
-            g2.fill(body);
         }
-        if (this.useOutlinePaint) {
-            g2.setPaint(outlinePaint);
-        }
-        else {
-            g2.setPaint(p);
-        }
+        g2.fill(body);
         g2.draw(body);
 
         // add an entity for the item...
@@ -909,5 +896,4 @@ public class CandlestickRenderer extends AbstractXYItemRenderer
         this.downPaint = SerialUtils.readPaint(stream);
         this.volumePaint = SerialUtils.readPaint(stream);
     }
-
 }


### PR DESCRIPTION
CandlestickRenderer fills candles with red or green but borders are always red:
 
![CandlestickRenderer-always-red](https://user-images.githubusercontent.com/77241070/104850835-6a1ca180-5902-11eb-85a5-5e1048f0358f.png)
It is mode convenient to draw borders also with red or green:

![CandlestickRenderer-green-and-red](https://user-images.githubusercontent.com/77241070/104850869-ac45e300-5902-11eb-9174-0e01f5ce27fe.png)