### PR TITLE
Export org.jfree.chart.api and org.jfree.chart.plot.pie from module

### DIFF
--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -5,6 +5,7 @@ module org.jfree.chart {
     requires java.desktop;
     exports org.jfree.chart;
     exports org.jfree.chart.annotations;
+    exports org.jfree.chart.api;
     exports org.jfree.chart.axis;
     exports org.jfree.chart.date;
     exports org.jfree.chart.entity;
@@ -15,6 +16,7 @@ module org.jfree.chart {
     exports org.jfree.chart.plot;
     exports org.jfree.chart.plot.dial;
     exports org.jfree.chart.plot.flow;
+    exports org.jfree.chart.plot.pie;
     exports org.jfree.chart.renderer;
     exports org.jfree.chart.renderer.category;
     exports org.jfree.chart.renderer.xy;


### PR DESCRIPTION
I've forked jfreechart-fx and made it use jfreechart 2.0, but jfreechart does not export some packages jfreechart-fx needs. So I've added them.
Please see https://github.com/jfree/jfreechart-fx/pull/19