### PR TITLE
Adding means to measure and illustrate differences in XYPlots

### DIFF
--- a/src/main/java/org/jfree/chart/annotations/AbstractXYAnnotation.java
+++ b/src/main/java/org/jfree/chart/annotations/AbstractXYAnnotation.java
@@ -31,6 +31,7 @@
  *
  * Original Author:  David Gilbert (for Object Refinery Limited);
  * Contributor(s):   Peter Kolb (patch 2809117);
+ *                   Yuri Blankenstein;
  *
  */
 
@@ -143,6 +144,7 @@ public abstract class AbstractXYAnnotation extends AbstractAnnotation
      * @param rendererIndex  the renderer index.
      * @param toolTipText  the tool tip text.
      * @param urlText  the URL text.
+     * @see #createEntity(Shape, int, String, String)
      */
     protected void addEntity(PlotRenderingInfo info,
                              Shape hotspot, int rendererIndex,
@@ -154,9 +156,25 @@ public abstract class AbstractXYAnnotation extends AbstractAnnotation
         if (entities == null) {
             return;
         }
-        XYAnnotationEntity entity = new XYAnnotationEntity(hotspot,
-                rendererIndex, toolTipText, urlText);
+        XYAnnotationEntity entity = createEntity(hotspot, rendererIndex,
+                toolTipText, urlText);
         entities.add(entity);
+    }
+    
+    /**
+     * A factory method for creating an {@link XYAnnotationEntity} for this
+     * annotation.
+     * 
+     * @param hotspot       the hotspot area.
+     * @param rendererIndex the renderer index.
+     * @param toolTipText   the tool tip text.
+     * @param urlText       the URL text.
+     * @return the created entity
+     */
+    protected XYAnnotationEntity createEntity(Shape hotspot, int rendererIndex,
+            String toolTipText, String urlText) {
+        return new XYAnnotationEntity(hotspot, this, rendererIndex, toolTipText,
+                urlText);
     }
 
     /**

--- a/src/main/java/org/jfree/chart/annotations/XYMeasurementAnnotation.java
+++ b/src/main/java/org/jfree/chart/annotations/XYMeasurementAnnotation.java
@@ -1,0 +1,872 @@
+/* ===========================================================
+ * JFreeChart : a free chart library for the Java(tm) platform
+ * ===========================================================
+ *
+ * (C) Copyright 2000-2021, by Object Refinery Limited and Contributors.
+ *
+ * Project Info:  http://www.jfree.org/jfreechart/index.html
+ *
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ * [Oracle and Java are registered trademarks of Oracle and/or its affiliates. 
+ * Other names may be trademarks of their respective owners.]
+ *
+ * ---------------------
+ * XYMeasurementAnnotation.java
+ * ---------------------
+ * (C) Copyright 2021, by Object Refinery Limited.
+ *
+ * Original Author:  Yuri Blankenstein (for ESI TNO);
+ *
+ */
+package org.jfree.chart.annotations;
+
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Font;
+import java.awt.Graphics2D;
+import java.awt.Paint;
+import java.awt.Shape;
+import java.awt.Stroke;
+import java.awt.geom.GeneralPath;
+import java.awt.geom.Line2D;
+import java.awt.geom.Point2D;
+import java.awt.geom.Rectangle2D;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+
+import org.jfree.chart.HashUtils;
+import org.jfree.chart.axis.ValueAxis;
+import org.jfree.chart.entity.MovableChartEntity;
+import org.jfree.chart.entity.XYAnnotationEntity;
+import org.jfree.chart.entity.XYMeasurementAnnotationEntity;
+import org.jfree.chart.event.AnnotationChangeEvent;
+import org.jfree.chart.plot.Plot;
+import org.jfree.chart.plot.PlotOrientation;
+import org.jfree.chart.plot.PlotRenderingInfo;
+import org.jfree.chart.plot.XYPlot;
+import org.jfree.chart.text.TextUtils;
+import org.jfree.chart.ui.RectangleEdge;
+import org.jfree.chart.ui.TextAnchor;
+import org.jfree.chart.util.Args;
+import org.jfree.chart.util.PublicCloneable;
+import org.jfree.chart.util.SerialUtils;
+
+/**
+ * An annotation to illustrate a measurement between two points on an XYPlot.
+ */
+public class XYMeasurementAnnotation extends XYTextAnnotation
+        implements Cloneable, PublicCloneable, Serializable {
+
+    private static final long serialVersionUID = -3774229610407585254L;
+
+    /** Specifies how to draw this annotation. */
+    public enum Orientation {
+        /** Draw this annotation horizontally. */
+        HORIZONTAL,
+        /** Draw this annotation vertically. */
+        VERTICAL
+    };
+
+    /** The default label offset (in Java2D units). */
+    public static final double DEFAULT_LABEL_OFFSET = 30.0;
+
+    /** The default arrow length (in Java2D units). */
+    public static final double DEFAULT_ARROW_LENGTH = 10.0;
+
+    /** The default arrow width (in Java2D units). */
+    public static final double DEFAULT_ARROW_WIDTH = 5.0;
+
+    /** The annotation orientation */
+    private Orientation orientation;
+
+    /** The second x-coordinate. */
+    private double x2;
+
+    /** The second y-coordinate. */
+    private double y2;
+
+    /** The length of the arrow head (in Java2D units). */
+    private double arrowLength;
+
+    /** The arrow width (in Java2D units, per side). */
+    private double arrowWidth;
+
+    /** The arrow stroke. */
+    private transient Stroke arrowStroke;
+
+    /** The arrow paint. */
+    private transient Paint arrowPaint;
+
+    /** The measure line stroke. */
+    private transient Stroke measureLineStroke;
+
+    /** The measure line paint. */
+    private transient Paint measureLinePaint;
+
+    /** The radius from the base point to the anchor point for the label. */
+    private double labelOffset;
+
+    /**
+     * If {@code true}, always creates an entity, regardless of tooltip or url
+     */
+    private boolean baseCreateEntity;
+
+    /**
+     * Creates a new annotation to be displayed at the given coordinates. The
+     * coordinates are specified in data space (they will be converted to Java2D
+     * space for display).
+     *
+     * @param orientation the orientation to use when drawing this annotation.
+     * @param text        the text ({@code null} not permitted).
+     * @param p1          the first coordinate (in data space).
+     * @param p2          the second coordinate (in data space).
+     */
+    public XYMeasurementAnnotation(Orientation orientation, String text,
+            Point2D p1, Point2D p2) {
+        this(orientation, text, p1.getX(), p1.getY(), p2.getX(), p2.getY());
+    }
+
+    /**
+     * Creates a new annotation to be displayed at the given coordinates. The
+     * coordinates are specified in data space (they will be converted to Java2D
+     * space for display).
+     *
+     * @param orientation the orientation to use when drawing this annotation.
+     * @param text        the text ({@code null} not permitted).
+     * @param x1          the first x-coordinate (in data space).
+     * @param y1          the first y-coordinate (in data space).
+     * @param x2          the second x-coordinate (in data space).
+     * @param y2          the second y-coordinate (in data space).
+     */
+    public XYMeasurementAnnotation(Orientation orientation, String text,
+            double x1, double y1, double x2, double y2) {
+        super(text, x1, y1);
+        this.orientation = orientation;
+        this.x2 = x2;
+        this.y2 = y2;
+        this.arrowLength = DEFAULT_ARROW_LENGTH;
+        this.arrowWidth = DEFAULT_ARROW_WIDTH;
+        this.labelOffset = DEFAULT_LABEL_OFFSET;
+        this.arrowStroke = new BasicStroke(1.0f);
+        this.arrowPaint = Color.BLACK;
+        this.measureLineStroke = new BasicStroke(2.0f);
+        this.measureLinePaint = Color.BLACK;
+        this.baseCreateEntity = true;
+
+        setPaint(Color.RED);
+        setFont(getFont().deriveFont(Font.BOLD));
+        setBackgroundPaint(Color.WHITE);
+        setOutlineVisible(true);
+        setOutlinePaint(Color.DARK_GRAY);
+    }
+
+    /**
+     * Returns how this annotation is drawn.
+     * 
+     * @return how this annotation is drawn
+     * @see #setOrientation(Orientation)
+     * @see #drawHorizontal(Graphics2D, XYPlot, Rectangle2D, ValueAxis,
+     *      ValueAxis, int, PlotRenderingInfo)
+     * @see #drawVertical(Graphics2D, XYPlot, Rectangle2D, ValueAxis, ValueAxis,
+     *      int, PlotRenderingInfo)
+     */
+    public Orientation getOrientation() {
+        return orientation;
+    }
+
+    /**
+     * Sets the orientation to use when drawing this annotation.
+     * 
+     * @param orientation the orientation to use when drawing this annotation.
+     * @see #getOrientation()
+     */
+    public void setOrientation(Orientation orientation) {
+        Args.nullNotPermitted(orientation, "orientation");
+        this.orientation = orientation;
+        fireAnnotationChanged();
+    }
+
+    /**
+     * Returns the x2 coordinate for the text anchor point (measured against the
+     * domain axis).
+     *
+     * @return The x2 coordinate (in data space).
+     *
+     * @see #setX2(double)
+     */
+    public double getX2() {
+        return this.x2;
+    }
+
+    /**
+     * Sets the x2 coordinate for the text anchor point (measured against the
+     * domain axis) and sends an {@link AnnotationChangeEvent} to all registered
+     * listeners.
+     *
+     * @param x the x2 coordinate (in data space).
+     *
+     * @see #getX()
+     */
+    public void setX2(double x) {
+        this.x2 = x;
+        fireAnnotationChanged();
+    }
+
+    /**
+     * Returns the y2 coordinate for the text anchor point (measured against the
+     * range axis).
+     *
+     * @return The y2 coordinate (in data space).
+     *
+     * @see #setY2(double)
+     */
+    public double getY2() {
+        return this.y2;
+    }
+
+    /**
+     * Sets the y2 coordinate for the text anchor point (measured against the
+     * range axis) and sends an {@link AnnotationChangeEvent} to all registered
+     * listeners.
+     *
+     * @param y the y2 coordinate.
+     *
+     * @see #getY2()
+     */
+    public void setY2(double y) {
+        this.y2 = y;
+        fireAnnotationChanged();
+    }
+
+    /**
+     * Returns the label offset.
+     *
+     * @return The label offset (in Java2D units).
+     *
+     * @see #setLabelOffset(double)
+     */
+    public double getLabelOffset() {
+        return this.labelOffset;
+    }
+
+    /**
+     * Sets the label offset (from the arrow base, continuing in a straight
+     * line, in Java2D units) and sends an {@link AnnotationChangeEvent} to all
+     * registered listeners.
+     *
+     * @param offset the offset (in Java2D units).
+     *
+     * @see #getLabelOffset()
+     */
+    public void setLabelOffset(double offset) {
+        this.labelOffset = offset;
+        fireAnnotationChanged();
+    }
+
+    /**
+     * Returns the arrow length.
+     *
+     * @return The arrow length.
+     *
+     * @see #setArrowLength(double)
+     */
+    public double getArrowLength() {
+        return this.arrowLength;
+    }
+
+    /**
+     * Sets the arrow length and sends an {@link AnnotationChangeEvent} to all
+     * registered listeners.
+     *
+     * @param length the length.
+     *
+     * @see #getArrowLength()
+     */
+    public void setArrowLength(double length) {
+        this.arrowLength = length;
+        fireAnnotationChanged();
+    }
+
+    /**
+     * Returns the arrow width.
+     *
+     * @return The arrow width (in Java2D units).
+     *
+     * @see #setArrowWidth(double)
+     */
+    public double getArrowWidth() {
+        return this.arrowWidth;
+    }
+
+    /**
+     * Sets the arrow width and sends an {@link AnnotationChangeEvent} to all
+     * registered listeners.
+     *
+     * @param width the width (in Java2D units).
+     *
+     * @see #getArrowWidth()
+     */
+    public void setArrowWidth(double width) {
+        this.arrowWidth = width;
+        fireAnnotationChanged();
+    }
+
+    /**
+     * Returns the stroke used to draw the arrow line.
+     *
+     * @return The arrow stroke (never {@code null}).
+     *
+     * @see #setArrowStroke(Stroke)
+     */
+    public Stroke getArrowStroke() {
+        return this.arrowStroke;
+    }
+
+    /**
+     * Sets the stroke used to draw the arrow line and sends an
+     * {@link AnnotationChangeEvent} to all registered listeners.
+     *
+     * @param stroke the stroke ({@code null} not permitted).
+     *
+     * @see #getArrowStroke()
+     */
+    public void setArrowStroke(Stroke stroke) {
+        Args.nullNotPermitted(stroke, "stroke");
+        this.arrowStroke = stroke;
+        fireAnnotationChanged();
+    }
+
+    /**
+     * Returns the paint used for the arrow.
+     *
+     * @return The arrow paint (never {@code null}).
+     *
+     * @see #setArrowPaint(Paint)
+     */
+    public Paint getArrowPaint() {
+        return this.arrowPaint;
+    }
+
+    /**
+     * Sets the paint used for the arrow and sends an
+     * {@link AnnotationChangeEvent} to all registered listeners.
+     *
+     * @param paint the arrow paint ({@code null} not permitted).
+     *
+     * @see #getArrowPaint()
+     */
+    public void setArrowPaint(Paint paint) {
+        Args.nullNotPermitted(paint, "paint");
+        this.arrowPaint = paint;
+        fireAnnotationChanged();
+    }
+
+    /**
+     * Returns the stroke used to draw the measure line.
+     *
+     * @return The measure line stroke (never {@code null}).
+     *
+     * @see #setMeasureLineStroke(Stroke)
+     */
+    public Stroke getMeasureLineStroke() {
+        return measureLineStroke;
+    }
+
+    /**
+     * Sets the stroke used to draw the measure line and sends an
+     * {@link AnnotationChangeEvent} to all registered listeners.
+     *
+     * @param stroke the stroke ({@code null} not permitted).
+     *
+     * @see #getMeasureLineStroke()
+     */
+    public void setMeasureLineStroke(Stroke stroke) {
+        Args.nullNotPermitted(stroke, "stroke");
+        this.measureLineStroke = stroke;
+        fireAnnotationChanged();
+    }
+
+    /**
+     * Returns the paint used for the measure line.
+     *
+     * @return The measure line paint (never {@code null}).
+     *
+     * @see #setMeasureLinePaint(Paint)
+     */
+    public Paint getMeasureLinePaint() {
+        return measureLinePaint;
+    }
+
+    /**
+     * Sets the paint used for the measure line and sends an
+     * {@link AnnotationChangeEvent} to all registered listeners.
+     *
+     * @param paint the measure line paint ({@code null} not permitted).
+     *
+     * @see #getMeasureLinePaint()
+     */
+    public void setMeasureLinePaint(Paint paint) {
+        Args.nullNotPermitted(paint, "paint");
+        this.measureLinePaint = paint;
+        fireAnnotationChanged();
+    }
+
+    /**
+     * Returns {@code true} (is default) if a chart entity is always created.
+     * This is required to enable the chart entity to be
+     * {@link MovableChartEntity movable}.
+     * 
+     * @return {@code true} if a chart entity is always created, {@code false}
+     *         otherwise.
+     */
+    public boolean isBaseCreateEntity() {
+        return baseCreateEntity;
+    }
+
+    /**
+     * If {@code true}, always creates an entity, regardless of tooltip or url.
+     * 
+     * @param createEntity {@code true} if a chart entity needs to be created at
+     *                     all times.
+     * @see #isBaseCreateEntity()
+     */
+    public void setBaseCreateEntity(boolean createEntity) {
+        this.baseCreateEntity = createEntity;
+        fireAnnotationChanged();
+    }
+
+    /**
+     * @return {@code true} if a chart entity should be created, {@code false}
+     *         otherwise.
+     */
+    protected boolean isCreateEntity() {
+        return isBaseCreateEntity() || getToolTipText() != null
+                || getURL() != null;
+    }
+
+    @Override
+    public void draw(Graphics2D g2, XYPlot plot, Rectangle2D dataArea,
+            ValueAxis domainAxis, ValueAxis rangeAxis, int rendererIndex,
+            PlotRenderingInfo info) {
+        if (orientation == Orientation.HORIZONTAL) {
+            drawHorizontal(g2, plot, dataArea, domainAxis, rangeAxis,
+                    rendererIndex, info);
+        } else {
+            drawVertical(g2, plot, dataArea, domainAxis, rangeAxis,
+                    rendererIndex, info);
+        }
+    }
+
+    /**
+     * Draws the annotation horizontally.
+     *
+     * @param g2            the graphics device.
+     * @param plot          the plot.
+     * @param dataArea      the data area.
+     * @param domainAxis    the domain axis.
+     * @param rangeAxis     the range axis.
+     * @param rendererIndex the renderer index.
+     * @param info          if supplied, this info object will be populated with
+     *                      entity information.
+     */
+    protected void drawHorizontal(Graphics2D g2, XYPlot plot,
+            Rectangle2D dataArea, ValueAxis domainAxis, ValueAxis rangeAxis,
+            int rendererIndex, PlotRenderingInfo info) {
+        PlotOrientation orientation = plot.getOrientation();
+        RectangleEdge domainEdge = Plot.resolveDomainAxisLocation(
+                plot.getDomainAxisLocation(), orientation);
+        RectangleEdge rangeEdge = Plot.resolveRangeAxisLocation(
+                plot.getRangeAxisLocation(), orientation);
+        double j2DX1 = domainAxis.valueToJava2D(getX(), dataArea, domainEdge);
+        double j2DY1 = rangeAxis.valueToJava2D(getY(), dataArea, rangeEdge);
+        double j2DX2 = domainAxis.valueToJava2D(getX2(), dataArea, domainEdge);
+        double j2DY2 = rangeAxis.valueToJava2D(getY2(), dataArea, rangeEdge);
+        if (orientation == PlotOrientation.HORIZONTAL) {
+            double temp = j2DX1;
+            j2DX1 = j2DY1;
+            j2DY1 = temp;
+
+            temp = j2DX2;
+            j2DX2 = j2DY2;
+            j2DY2 = temp;
+        }
+
+        double j2DXleft = Math.min(j2DX1, j2DX2);
+        double j2DXright = Math.max(j2DX1, j2DX2);
+        double labelX = (j2DXleft + j2DXright) / 2;
+        double labelY = j2DY1 - this.labelOffset;
+
+        g2.setStroke(this.measureLineStroke);
+        g2.setPaint(this.measureLinePaint);
+        g2.draw(new Line2D.Double(j2DX1,
+                Math.min(labelY - this.arrowWidth, j2DY1), j2DX1,
+                Math.max(labelY + this.arrowWidth, j2DY1)));
+        g2.draw(new Line2D.Double(j2DX2,
+                Math.min(labelY - this.arrowWidth, j2DY2), j2DX2,
+                Math.max(labelY + this.arrowWidth, j2DY2)));
+
+        String text = getText();
+        TextAnchor textAnchor = getTextAnchor();
+        g2.setFont(getFont());
+        g2.setStroke(this.arrowStroke);
+        g2.setPaint(this.arrowPaint);
+        Shape hotspot = TextUtils.calculateRotatedStringBounds(text, g2,
+                (float) labelX, (float) labelY, textAnchor, getRotationAngle(),
+                getRotationAnchor());
+
+        if (hotspot.getBounds2D().getWidth() > j2DXright - j2DXleft
+                - 3 * this.arrowLength) {
+            // The text doesn't fit within the measurement, so place it to the
+            // right like
+            // ->|--|<- text
+            // | |
+            labelX = j2DXright + this.arrowLength * 2;
+            textAnchor = TextAnchor.CENTER_LEFT;
+
+            hotspot = TextUtils.calculateRotatedStringBounds(text, g2,
+                    (float) labelX, (float) labelY, textAnchor,
+                    getRotationAngle(), getRotationAnchor());
+
+            g2.draw(new Line2D.Double(j2DXleft - this.arrowLength * 2, labelY,
+                    j2DXright + this.arrowLength * 2, labelY));
+
+            GeneralPath arrowLeft = new GeneralPath();
+            arrowLeft.moveTo((float) j2DXleft, (float) labelY);
+            arrowLeft.lineTo((float) j2DXleft - this.arrowLength,
+                    (float) labelY - this.arrowWidth);
+            arrowLeft.lineTo((float) j2DXleft - this.arrowLength,
+                    (float) labelY + this.arrowWidth);
+            arrowLeft.closePath();
+            g2.fill(arrowLeft);
+
+            GeneralPath arrowRight = new GeneralPath();
+            arrowRight.moveTo((float) j2DXright, (float) labelY);
+            arrowRight.lineTo((float) j2DXright + this.arrowLength,
+                    (float) labelY - this.arrowWidth);
+            arrowRight.lineTo((float) j2DXright + this.arrowLength,
+                    (float) labelY + this.arrowWidth);
+            arrowRight.closePath();
+            g2.fill(arrowRight);
+        } else {
+            // The text fits, so draw like
+            // |<--text-->|
+            // | |
+            g2.draw(new Line2D.Double(j2DXleft, labelY, j2DXright, labelY));
+
+            GeneralPath arrowLeft = new GeneralPath();
+            arrowLeft.moveTo((float) j2DXleft, (float) labelY);
+            arrowLeft.lineTo((float) j2DXleft + this.arrowLength,
+                    (float) labelY - this.arrowWidth);
+            arrowLeft.lineTo((float) j2DXleft + this.arrowLength,
+                    (float) labelY + this.arrowWidth);
+            arrowLeft.closePath();
+            g2.fill(arrowLeft);
+
+            GeneralPath arrowRight = new GeneralPath();
+            arrowRight.moveTo((float) j2DXright, (float) labelY);
+            arrowRight.lineTo((float) j2DXright - this.arrowLength,
+                    (float) labelY - this.arrowWidth);
+            arrowRight.lineTo((float) j2DXright - this.arrowLength,
+                    (float) labelY + this.arrowWidth);
+            arrowRight.closePath();
+            g2.fill(arrowRight);
+        }
+
+        if (text.isEmpty()) {
+            return;
+        }
+
+        if (getBackgroundPaint() != null) {
+            g2.setPaint(getBackgroundPaint());
+            g2.fill(hotspot);
+        }
+        g2.setPaint(getPaint());
+        TextUtils.drawRotatedString(getText(), g2, (float) labelX,
+                (float) labelY, textAnchor, getRotationAngle(),
+                getRotationAnchor());
+        if (isOutlineVisible()) {
+            g2.setStroke(getOutlineStroke());
+            g2.setPaint(getOutlinePaint());
+            g2.draw(hotspot);
+        }
+
+        if (isCreateEntity()) {
+            addEntity(info, hotspot, rendererIndex, getToolTipText(), getURL());
+        }
+    }
+
+    /**
+     * Draws the annotation vertically.
+     *
+     * @param g2            the graphics device.
+     * @param plot          the plot.
+     * @param dataArea      the data area.
+     * @param domainAxis    the domain axis.
+     * @param rangeAxis     the range axis.
+     * @param rendererIndex the renderer index.
+     * @param info          if supplied, this info object will be populated with
+     *                      entity information.
+     */
+    protected void drawVertical(Graphics2D g2, XYPlot plot,
+            Rectangle2D dataArea, ValueAxis domainAxis, ValueAxis rangeAxis,
+            int rendererIndex, PlotRenderingInfo info) {
+        PlotOrientation orientation = plot.getOrientation();
+        RectangleEdge domainEdge = Plot.resolveDomainAxisLocation(
+                plot.getDomainAxisLocation(), orientation);
+        RectangleEdge rangeEdge = Plot.resolveRangeAxisLocation(
+                plot.getRangeAxisLocation(), orientation);
+        double j2DX1 = domainAxis.valueToJava2D(getX(), dataArea, domainEdge);
+        double j2DY1 = rangeAxis.valueToJava2D(getY(), dataArea, rangeEdge);
+        double j2DX2 = domainAxis.valueToJava2D(getX2(), dataArea, domainEdge);
+        double j2DY2 = rangeAxis.valueToJava2D(getY2(), dataArea, rangeEdge);
+        if (orientation == PlotOrientation.HORIZONTAL) {
+            double temp = j2DX1;
+            j2DX1 = j2DY1;
+            j2DY1 = temp;
+
+            temp = j2DX2;
+            j2DX2 = j2DY2;
+            j2DY2 = temp;
+        }
+
+        double j2DYtop = Math.min(j2DY1, j2DY2);
+        double j2DYbottom = Math.max(j2DY1, j2DY2);
+        double labelY = (j2DYtop + j2DYbottom) / 2;
+        double labelX = j2DX1 + this.labelOffset;
+
+        g2.setStroke(this.measureLineStroke);
+        g2.setPaint(this.measureLinePaint);
+        g2.draw(new Line2D.Double(Math.min(labelX - this.arrowWidth, j2DX1),
+                j2DY1, Math.max(labelX + this.arrowWidth, j2DX1), j2DY1));
+        g2.draw(new Line2D.Double(Math.min(labelX - this.arrowWidth, j2DX2),
+                j2DY2, Math.max(labelX + this.arrowWidth, j2DX2), j2DY2));
+
+        String text = getText();
+        TextAnchor textAnchor = getTextAnchor();
+        g2.setFont(getFont());
+        g2.setStroke(this.arrowStroke);
+        g2.setPaint(this.arrowPaint);
+        Shape hotspot = TextUtils.calculateRotatedStringBounds(text, g2,
+                (float) labelX, (float) labelY, textAnchor, getRotationAngle(),
+                getRotationAnchor());
+
+        if (hotspot.getBounds2D().getHeight() > j2DYbottom - j2DYtop
+                - 3 * this.arrowLength) {
+            // The text doesn't fit within the measurement, so place it at the
+            // top like
+            // text
+            // |
+            // v
+            // ----
+            // |
+            // ----
+            // ^
+            // |
+            labelY = j2DYtop - this.arrowLength * 2;
+            textAnchor = TextAnchor.BOTTOM_CENTER;
+
+            hotspot = TextUtils.calculateRotatedStringBounds(text, g2,
+                    (float) labelX, (float) labelY, textAnchor,
+                    getRotationAngle(), getRotationAnchor());
+
+            g2.draw(new Line2D.Double(labelX, j2DYtop - this.arrowLength * 2,
+                    labelX, j2DYbottom + this.arrowLength * 2));
+
+            GeneralPath arrowTop = new GeneralPath();
+            arrowTop.moveTo((float) labelX, (float) j2DYtop);
+            arrowTop.lineTo((float) labelX - this.arrowWidth,
+                    (float) j2DYtop - this.arrowLength);
+            arrowTop.lineTo((float) labelX + this.arrowWidth,
+                    (float) j2DYtop - this.arrowLength);
+            arrowTop.closePath();
+            g2.fill(arrowTop);
+
+            GeneralPath arrowBottom = new GeneralPath();
+            arrowBottom.moveTo((float) labelX, (float) j2DYbottom);
+            arrowBottom.lineTo((float) labelX - this.arrowWidth,
+                    (float) j2DYbottom + this.arrowLength);
+            arrowBottom.lineTo((float) labelX + this.arrowWidth,
+                    (float) j2DYbottom + this.arrowLength);
+            arrowBottom.closePath();
+            g2.fill(arrowBottom);
+        } else {
+            // The text fits, so draw like
+            // ----
+            // ^
+            // |
+            // text
+            // |
+            // v
+            // ----
+            g2.draw(new Line2D.Double(labelX, j2DYtop, labelX, j2DYbottom));
+
+            GeneralPath arrowTop = new GeneralPath();
+            arrowTop.moveTo((float) labelX, (float) j2DYtop);
+            arrowTop.lineTo((float) labelX - this.arrowWidth,
+                    (float) j2DYtop + this.arrowLength);
+            arrowTop.lineTo((float) labelX + this.arrowWidth,
+                    (float) j2DYtop + this.arrowLength);
+            arrowTop.closePath();
+            g2.fill(arrowTop);
+
+            GeneralPath arrowBottom = new GeneralPath();
+            arrowBottom.moveTo((float) labelX, (float) j2DYbottom);
+            arrowBottom.lineTo((float) labelX - this.arrowWidth,
+                    (float) j2DYbottom - this.arrowLength);
+            arrowBottom.lineTo((float) labelX + this.arrowWidth,
+                    (float) j2DYbottom - this.arrowLength);
+            arrowBottom.closePath();
+            g2.fill(arrowBottom);
+        }
+
+        if (text.isEmpty()) {
+            return;
+        }
+
+        if (getBackgroundPaint() != null) {
+            g2.setPaint(getBackgroundPaint());
+            g2.fill(hotspot);
+        }
+        g2.setPaint(getPaint());
+        TextUtils.drawRotatedString(getText(), g2, (float) labelX,
+                (float) labelY, textAnchor, getRotationAngle(),
+                getRotationAnchor());
+        if (isOutlineVisible()) {
+            g2.setStroke(getOutlineStroke());
+            g2.setPaint(getOutlinePaint());
+            g2.draw(hotspot);
+        }
+
+        if (isCreateEntity()) {
+            addEntity(info, hotspot, rendererIndex, getToolTipText(), getURL());
+        }
+    }
+
+    @Override
+    protected XYAnnotationEntity createEntity(Shape hotspot, int rendererIndex,
+            String toolTipText, String urlText) {
+        return new XYMeasurementAnnotationEntity(hotspot, this, rendererIndex,
+                toolTipText, urlText);
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = super.hashCode();
+        long temp;
+        temp = Double.doubleToLongBits(arrowLength);
+        result = prime * result + (int) (temp ^ (temp >>> 32));
+        result = prime * result + HashUtils.hashCodeForPaint(arrowPaint);
+        result = prime * result + arrowStroke.hashCode();
+        temp = Double.doubleToLongBits(arrowWidth);
+        result = prime * result + (int) (temp ^ (temp >>> 32));
+        result = prime * result + (baseCreateEntity ? 1231 : 1237);
+        temp = Double.doubleToLongBits(labelOffset);
+        result = prime * result + (int) (temp ^ (temp >>> 32));
+        result = prime * result + HashUtils.hashCodeForPaint(measureLinePaint);
+        result = prime * result + measureLineStroke.hashCode();
+        result = prime * result + orientation.hashCode();
+        temp = Double.doubleToLongBits(x2);
+        result = prime * result + (int) (temp ^ (temp >>> 32));
+        temp = Double.doubleToLongBits(y2);
+        result = prime * result + (int) (temp ^ (temp >>> 32));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (!super.equals(obj))
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        XYMeasurementAnnotation other = (XYMeasurementAnnotation) obj;
+        if (Double.doubleToLongBits(arrowLength) != Double
+                .doubleToLongBits(other.arrowLength))
+            return false;
+        if (!arrowPaint.equals(other.arrowPaint))
+            return false;
+        if (!arrowStroke.equals(other.arrowStroke))
+            return false;
+        if (Double.doubleToLongBits(arrowWidth) != Double
+                .doubleToLongBits(other.arrowWidth))
+            return false;
+        if (baseCreateEntity != other.baseCreateEntity)
+            return false;
+        if (Double.doubleToLongBits(labelOffset) != Double
+                .doubleToLongBits(other.labelOffset))
+            return false;
+        if (!measureLinePaint.equals(other.measureLinePaint))
+            return false;
+        if (!measureLineStroke.equals(other.measureLineStroke))
+            return false;
+        if (orientation != other.orientation)
+            return false;
+        if (Double.doubleToLongBits(x2) != Double.doubleToLongBits(other.x2))
+            return false;
+        if (Double.doubleToLongBits(y2) != Double.doubleToLongBits(other.y2))
+            return false;
+        return true;
+    }
+
+    /**
+     * Returns a clone of the annotation.
+     *
+     * @return A clone.
+     *
+     * @throws CloneNotSupportedException if the annotation can't be cloned.
+     */
+    @Override
+    public Object clone() throws CloneNotSupportedException {
+        return super.clone();
+    }
+
+    /**
+     * Provides serialization support.
+     *
+     * @param stream the output stream.
+     *
+     * @throws IOException if there is an I/O error.
+     */
+    private void writeObject(ObjectOutputStream stream) throws IOException {
+        stream.defaultWriteObject();
+        SerialUtils.writePaint(this.arrowPaint, stream);
+        SerialUtils.writeStroke(this.arrowStroke, stream);
+        SerialUtils.writePaint(this.measureLinePaint, stream);
+        SerialUtils.writeStroke(this.measureLineStroke, stream);
+    }
+
+    /**
+     * Provides serialization support.
+     *
+     * @param stream the input stream.
+     *
+     * @throws IOException            if there is an I/O error.
+     * @throws ClassNotFoundException if there is a classpath problem.
+     */
+    private void readObject(ObjectInputStream stream)
+            throws IOException, ClassNotFoundException {
+        stream.defaultReadObject();
+        this.arrowPaint = SerialUtils.readPaint(stream);
+        this.arrowStroke = SerialUtils.readStroke(stream);
+        this.measureLinePaint = SerialUtils.readPaint(stream);
+        this.measureLineStroke = SerialUtils.readStroke(stream);
+    }
+}

--- a/src/main/java/org/jfree/chart/entity/MovableChartEntity.java
+++ b/src/main/java/org/jfree/chart/entity/MovableChartEntity.java
@@ -1,0 +1,75 @@
+/* ===========================================================
+ * JFreeChart : a free chart library for the Java(tm) platform
+ * ===========================================================
+ *
+ * (C) Copyright 2000-2021, by Object Refinery Limited and Contributors.
+ *
+ * Project Info:  http://www.jfree.org/jfreechart/index.html
+ *
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ * [Oracle and Java are registered trademarks of Oracle and/or its affiliates. 
+ * Other names may be trademarks of their respective owners.]
+ *
+ * ---------------------
+ * MovableChartEntity.java
+ * ---------------------
+ * (C) Copyright 2021, by Object Refinery Limited.
+ *
+ * Original Author:  Yuri Blankenstein (for ESI TNO);
+ *
+ */
+package org.jfree.chart.entity;
+
+import java.awt.Shape;
+import java.awt.geom.Point2D;
+
+/**
+ * Support for moving chart entities by end-user
+ */
+public interface MovableChartEntity {
+    /**
+     * This method can be used to (dis)allow the move or to guide the move to a
+     * preferred location.
+     * 
+     * @param from starting point for the move
+     * @param to   end point for the move
+     * @return <code>to</code> to allow the move as is (default),
+     *         <code>null</code> to disallow the move and another point to guide
+     *         the move to an allowed location.
+     * @see MovableChartEntity#move(Point2D, Point2D)
+     */
+    default Point2D tryMove(Point2D from, Point2D to) {
+        return to;
+    }
+
+    /**
+     * Moves this entity to the <code>to</code> location.
+     * 
+     * @param from starting point for the move
+     * @param to   end point for the move
+     * @see #tryMove(Point2D, Point2D)
+     */
+    void move(Point2D from, Point2D to);
+
+    /**
+     * Returns the area occupied by the entity (in Java 2D space).
+     *
+     * @return The area (never <code>null</code>).
+     * @see ChartEntity#getArea()
+     */
+    Shape getArea();
+}

--- a/src/main/java/org/jfree/chart/entity/XYAnnotationEntity.java
+++ b/src/main/java/org/jfree/chart/entity/XYAnnotationEntity.java
@@ -39,6 +39,8 @@ package org.jfree.chart.entity;
 import java.awt.Shape;
 import java.io.Serializable;
 
+import org.jfree.chart.annotations.XYAnnotation;
+
 /**
  * A chart entity that represents an annotation on an
  * {@link org.jfree.chart.plot.XYPlot}.
@@ -49,6 +51,9 @@ public class XYAnnotationEntity extends ChartEntity
     /** For serialization. */
     private static final long serialVersionUID = 2340334068383660799L;
 
+    /** The annotation */
+    private transient XYAnnotation annotation;
+    
     /** The renderer index. */
     private int rendererIndex;
 
@@ -56,14 +61,25 @@ public class XYAnnotationEntity extends ChartEntity
      * Creates a new entity.
      *
      * @param hotspot  the area.
+     * @param annotation  the annotation.
      * @param rendererIndex  the rendererIndex (zero-based index).
      * @param toolTipText  the tool tip text.
      * @param urlText  the URL text for HTML image maps.
      */
-    public XYAnnotationEntity(Shape hotspot, int rendererIndex,
-                              String toolTipText, String urlText) {
+    public XYAnnotationEntity(Shape hotspot, XYAnnotation annotation,
+            int rendererIndex, String toolTipText, String urlText) {
         super(hotspot, toolTipText, urlText);
+        this.annotation = annotation;
         this.rendererIndex = rendererIndex;
+    }
+    
+    /**
+     * Returns the annotation this entity refers to.
+     *
+     * @return The annotation.
+     */
+    public XYAnnotation getAnnotation() {
+        return annotation;
     }
 
     /**

--- a/src/main/java/org/jfree/chart/entity/XYMeasurementAnnotationEntity.java
+++ b/src/main/java/org/jfree/chart/entity/XYMeasurementAnnotationEntity.java
@@ -1,0 +1,89 @@
+/* ===========================================================
+ * JFreeChart : a free chart library for the Java(tm) platform
+ * ===========================================================
+ *
+ * (C) Copyright 2000-2021, by Object Refinery Limited and Contributors.
+ *
+ * Project Info:  http://www.jfree.org/jfreechart/index.html
+ *
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ * [Oracle and Java are registered trademarks of Oracle and/or its affiliates. 
+ * Other names may be trademarks of their respective owners.]
+ *
+ * ---------------------
+ * XYMeasurementAnnotationEntity.java
+ * ---------------------
+ * (C) Copyright 2021, by Object Refinery Limited.
+ *
+ * Original Author:  Yuri Blankenstein (for ESI TNO);
+ *
+ */
+package org.jfree.chart.entity;
+
+import java.awt.Shape;
+import java.awt.geom.Point2D;
+
+import org.jfree.chart.annotations.XYMeasurementAnnotation;
+import org.jfree.chart.annotations.XYMeasurementAnnotation.Orientation;
+
+/**
+ * A chart entity that allows to reposition an {@link XYMeasurementAnnotation}.
+ */
+public class XYMeasurementAnnotationEntity extends XYAnnotationEntity
+        implements MovableChartEntity {
+    private static final long serialVersionUID = 3673107973561822541L;
+
+    /**
+     * Creates a new entity.
+     *
+     * @param hotspot  the area.
+     * @param annotation  the annotation.
+     * @param rendererIndex  the rendererIndex (zero-based index).
+     * @param toolTipText  the tool tip text.
+     * @param urlText  the URL text for HTML image maps.
+     */
+    public XYMeasurementAnnotationEntity(Shape hotspot,
+            XYMeasurementAnnotation annotation, int rendererIndex,
+            String toolTipText, String urlText) {
+        super(hotspot, annotation, rendererIndex, toolTipText, urlText);
+    }
+
+    @Override
+    public XYMeasurementAnnotation getAnnotation() {
+        return (XYMeasurementAnnotation) super.getAnnotation();
+    }
+
+    @Override
+    public Point2D tryMove(Point2D from, Point2D to) {
+        if (getAnnotation().getOrientation() == Orientation.HORIZONTAL) {
+            // This annotation can only be moved in Y-direction
+            return new Point2D.Double(from.getX(), to.getY());
+        } else {
+            // This annotation can only be moved in X-direction
+            return new Point2D.Double(to.getX(), from.getY());
+        }
+    }
+
+    @Override
+    public void move(Point2D from, Point2D to) {
+        double offset = getAnnotation().getLabelOffset();
+        double move = getAnnotation().getOrientation() == Orientation.HORIZONTAL ?
+                from.getY() - to.getY() :
+                to.getX() - from.getX();
+        getAnnotation().setLabelOffset(offset + move);
+    }
+}

--- a/src/main/java/org/jfree/chart/geom/Point2DNumber.java
+++ b/src/main/java/org/jfree/chart/geom/Point2DNumber.java
@@ -1,0 +1,130 @@
+/* ===========================================================
+ * JFreeChart : a free chart library for the Java(tm) platform
+ * ===========================================================
+ *
+ * (C) Copyright 2000-2021, by Object Refinery Limited and Contributors.
+ *
+ * Project Info:  http://www.jfree.org/jfreechart/index.html
+ *
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ * [Oracle and Java are registered trademarks of Oracle and/or its affiliates. 
+ * Other names may be trademarks of their respective owners.]
+ *
+ * ---------------------
+ * Point2DNumber.java
+ * ---------------------
+ * (C) Copyright 2021, by Object Refinery Limited.
+ *
+ * Original Author:  Yuri Blankenstein (for ESI TNO);
+ *
+ */
+package org.jfree.chart.geom;
+
+import java.awt.geom.Point2D;
+
+/**
+ * The {@link Point2DNumber} class defines a point that avoids rounding errors
+ * by referencing the original {@link Number} types.
+ */
+public class Point2DNumber extends Point2D {
+    /**
+     * The X coordinate of this <code>Point2D</code>.
+     */
+    public Number x;
+
+    /**
+     * The Y coordinate of this <code>Point2D</code>.
+     */
+    public Number y;
+
+    /**
+     * Constructs and initializes a <code>Point2D</code> with the specified
+     * coordinates.
+     *
+     * @param x the X coordinate of the newly constructed <code>Point2D</code>
+     * @param y the Y coordinate of the newly constructed <code>Point2D</code>
+     * @since 1.2
+     */
+    public Point2DNumber(Number x, Number y) {
+        this.x = x;
+        this.y = y;
+    }
+
+    @Override
+    public double getX() {
+        return x == null ? java.lang.Double.NaN : x.doubleValue();
+    }
+
+    @Override
+    public double getY() {
+        return y == null ? java.lang.Double.NaN : y.doubleValue();
+    }
+
+    @Override
+    public void setLocation(double x, double y) {
+        this.x = x;
+        this.y = y;
+    }
+
+    /**
+     * Sets the location of this <code>Point2D</code> to the specified
+     * {@link Number} coordinates.
+     *
+     * @param x the new X coordinate of this {@code Point2D}
+     * @param y the new Y coordinate of this {@code Point2D}
+     */
+    public void setLocation(Number x, Number y) {
+        this.x = x;
+        this.y = y;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((x == null) ? 0 : x.hashCode());
+        result = prime * result + ((y == null) ? 0 : y.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        Point2DNumber other = (Point2DNumber) obj;
+        if (x == null) {
+            if (other.x != null)
+                return false;
+        } else if (!x.equals(other.x))
+            return false;
+        if (y == null) {
+            if (other.y != null)
+                return false;
+        } else if (!y.equals(other.y))
+            return false;
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "Point2DNumber[" + x + ", " + y + "]";
+    }
+}

--- a/src/main/java/org/jfree/chart/plot/XYMeasureWithAnnotations.java
+++ b/src/main/java/org/jfree/chart/plot/XYMeasureWithAnnotations.java
@@ -1,0 +1,339 @@
+/* ===========================================================
+ * JFreeChart : a free chart library for the Java(tm) platform
+ * ===========================================================
+ *
+ * (C) Copyright 2000-2021, by Object Refinery Limited and Contributors.
+ *
+ * Project Info:  http://www.jfree.org/jfreechart/index.html
+ *
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ * [Oracle and Java are registered trademarks of Oracle and/or its affiliates. 
+ * Other names may be trademarks of their respective owners.]
+ *
+ * ---------------------
+ * XYMeasureWithAnnotations.java
+ * ---------------------
+ * (C) Copyright 2021, by Object Refinery Limited.
+ *
+ * Original Author:  Yuri Blankenstein (for ESI TNO);
+ *
+ */
+package org.jfree.chart.plot;
+
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.event.InputEvent;
+import java.awt.event.MouseEvent;
+import java.awt.geom.Point2D;
+import java.awt.geom.Rectangle2D;
+import java.util.function.BiFunction;
+import java.util.function.Predicate;
+
+import org.jfree.chart.ChartMouseEvent;
+import org.jfree.chart.ChartMouseListener;
+import org.jfree.chart.ChartPanel;
+import org.jfree.chart.annotations.XYAnnotation;
+import org.jfree.chart.annotations.XYMeasurementAnnotation;
+import org.jfree.chart.annotations.XYMeasurementAnnotation.Orientation;
+import org.jfree.chart.entity.XYItemEntity;
+import org.jfree.chart.geom.Point2DNumber;
+import org.jfree.chart.panel.CrosshairOverlay;
+import org.jfree.chart.util.Args;
+import org.jfree.data.xy.IntervalXYDataset;
+import org.jfree.data.xy.XYDataset;
+
+/**
+ * Allows the user to measure differences between points in the domain or range
+ * of an XYPlot. A user can start a measurement by clicking the mouse according
+ * to {@link #getMarkPredicate()}. A second click of the mouse according to
+ * {@link #getMarkPredicate()} will add an {@link XYMeasurementAnnotation} to
+ * the plot.
+ */
+public class XYMeasureWithAnnotations extends CrosshairOverlay
+        implements ChartMouseListener {
+    private static final long serialVersionUID = -7754581177397547320L;
+    
+    /** An enumeration that specifies which axis is measured. */
+    public enum MeasurementAxis {
+        /** Measure the {@link XYPlot#getDomainAxis() domain axis}*/
+        DOMAIN,
+        /** Measure the {@link XYPlot#getRangeAxis() range axis}*/
+        RANGE
+    };
+
+    /** An enumeration that specifies which axis is measured. */
+    private final MeasurementAxis measurementAxis;
+    /** A crosshair that illustrates what will be marked if the user starts a measurement. */
+    private final Crosshair movingCrosshair;
+    /** A crosshair that illustrates the start of a measurement. */
+    private final Crosshair markedCrosshair;
+    /** The start of a measurement. */
+    private transient Point2DNumber markedPoint;
+    /** The {@link MouseEvent} {@link Predicate} to filter mark events. */
+    private Predicate<MouseEvent> markPredicate = InputEvent::isAltDown;
+    /** The label provider to use for creating annotation labels. */
+    private BiFunction<Number, Number, String> annotationLabelProvider = 
+            (first, second) -> String.format("Difference: %f", 
+                    Math.abs(second.doubleValue() - first.doubleValue()));
+
+    /**
+     * Registers this utility to a {@link ChartPanel chartPanel} for a specific
+     * {@link MeasurementAxis axis}.
+     * 
+     * @param chartPanel the chart panel to register to.
+     * @param axis       the axis to measure.
+     * @return the created {@link XYMeasureWithAnnotations measure utility} that
+     *         was registered to {@code chartPanel}
+     */
+    public static XYMeasureWithAnnotations addToChartPanel(
+            ChartPanel chartPanel, MeasurementAxis axis) {
+        XYMeasureWithAnnotations instance = new XYMeasureWithAnnotations(axis);
+        instance.addToChartPanel(chartPanel);
+        return instance;
+    }
+
+    /**
+     * Creates this measurement overlay and starts listening for user mouse
+     * events.
+     * 
+     * @param axis the axis to measure.
+     */
+    public XYMeasureWithAnnotations(MeasurementAxis axis) {
+        Args.nullNotPermitted(axis, "axis");
+        measurementAxis = axis;
+        movingCrosshair = new Crosshair(Double.NaN, Color.GRAY,
+                new BasicStroke(1f));
+        markedCrosshair = new Crosshair(Double.NaN, Color.BLACK,
+                new BasicStroke(1f));
+        addCrosshair(movingCrosshair);
+        addCrosshair(markedCrosshair);
+    }
+    
+    private void addCrosshair(Crosshair crosshair) {
+        switch (measurementAxis) {
+        case DOMAIN:
+            addDomainCrosshair(crosshair);
+            break;
+        case RANGE:
+            addRangeCrosshair(crosshair);
+            break;
+        }
+    }
+
+    /**
+     * Registers this utility to a {@link ChartPanel chartPanel}.
+     * 
+     * @param chartPanel the chart panel to register to.
+     */
+    public void addToChartPanel(ChartPanel chartPanel) {
+        Args.nullNotPermitted(chartPanel, "chartPanel");
+        chartPanel.addOverlay(this);
+        chartPanel.addChartMouseListener(this);
+    }
+
+    /**
+     * Unregisters this utility from a {@link ChartPanel chartPanel}.
+     * 
+     * @param chartPanel the chart panel to unregister from.
+     */
+    public void removeFromChartPanel(ChartPanel chartPanel) {
+        Args.nullNotPermitted(chartPanel, "chartPanel");
+        chartPanel.removeChartMouseListener(this);
+        chartPanel.removeOverlay(this);
+    }
+    
+    /**
+     * Sets the label provider to use for creating annotation labels.
+     * 
+     * @param annotationLabelProvider the label provider for the annotation
+     */
+    public void setAnnotationLabelProvider(
+            BiFunction<Number, Number, String> annotationLabelProvider) {
+        Args.nullNotPermitted(annotationLabelProvider, "annotationLabelProvider");
+        this.annotationLabelProvider = annotationLabelProvider;
+    }
+
+    /**
+     * Returns the {@link MouseEvent} {@link Predicate} to filter mark events.
+     * 
+     * @return the {@link MouseEvent} {@link Predicate} to filter mark events.
+     */
+    public Predicate<MouseEvent> getMarkPredicate() {
+        return markPredicate;
+    }
+
+    /**
+     * Sets the {@link MouseEvent} {@link Predicate} to filter mark events.
+     * 
+     * @param markPredicate the {@link MouseEvent} {@link Predicate} to filter
+     *                      mark events.
+     */
+    public void setMarkPredicate(Predicate<MouseEvent> markPredicate) {
+        Args.nullNotPermitted(markPredicate, "markPredicate");
+        this.markPredicate = markPredicate;
+    }
+
+    @Override
+    public void chartMouseMoved(ChartMouseEvent event) {
+        Point2D crosshairPoint = getCrosshairPoint(event);
+        double crosshairValue = Double.NaN;
+        if (crosshairPoint != null) {
+            if (measurementAxis == MeasurementAxis.DOMAIN) {
+                crosshairValue = crosshairPoint.getX();
+            } else {
+                crosshairValue = crosshairPoint.getY();
+            }
+        }
+        movingCrosshair.setValue(crosshairValue);
+        event.getTrigger().consume();
+    }
+
+    @Override
+    public void chartMouseClicked(ChartMouseEvent event) {
+        if (markPredicate.test(event.getTrigger())) {
+            Point2DNumber crosshairPoint = getCrosshairPoint(event);
+            if (null != crosshairPoint && null != markedPoint) {
+                // Add the annotation
+                addAnnotation(event.getChart().getXYPlot(), markedPoint,
+                        crosshairPoint, event.getTrigger());
+                markedPoint = null;
+                markedCrosshair.setValue(Double.NaN);
+            } else {
+                markedPoint = crosshairPoint;
+                double crosshairValue = Double.NaN;
+                if (crosshairPoint != null) {
+                    if (measurementAxis == MeasurementAxis.DOMAIN) {
+                        crosshairValue = crosshairPoint.getX();
+                    } else {
+                        crosshairValue = crosshairPoint.getY();
+                    }
+                }
+                markedCrosshair.setValue(crosshairValue);
+            }
+            event.getTrigger().consume();
+        }
+    }
+
+    /**
+     * Calculates the point to snap the measurement to, returns {@code null} if
+     * not applicable.
+     * 
+     * @param event contains the current mouse location
+     * @return the point to snap the measurement to
+     */
+    protected Point2DNumber getCrosshairPoint(ChartMouseEvent event) {
+        if (!(event.getEntity() instanceof XYItemEntity)) {
+            return null;
+        }
+
+        XYItemEntity entity = (XYItemEntity) event.getEntity();
+        XYDataset dataset = entity.getDataset();
+        if (dataset instanceof IntervalXYDataset) {
+            IntervalXYDataset intervalDataset = (IntervalXYDataset) dataset;
+            
+            int mouseX = event.getTrigger().getX();
+            int mouseY = event.getTrigger().getY();
+            Rectangle2D entityBounds = entity.getArea().getBounds2D();
+            PlotOrientation plotOrientation = event.getChart().getXYPlot().getOrientation();
+            
+            Number x;
+            Number y;
+            if (measurementAxis == MeasurementAxis.DOMAIN) {
+                boolean snapDomainToStart = plotOrientation == PlotOrientation.VERTICAL ?
+                    mouseX < entityBounds.getCenterX() :
+                    mouseY > entityBounds.getCenterY();
+                x = snapDomainToStart
+                        ? intervalDataset.getStartX(entity.getSeriesIndex(), entity.getItem())
+                        : intervalDataset.getEndX(entity.getSeriesIndex(), entity.getItem());
+                y = intervalDataset.getY(entity.getSeriesIndex(), entity.getItem());
+            } else {
+                x = intervalDataset.getX(entity.getSeriesIndex(), entity.getItem());
+                boolean snapRangeToStart = plotOrientation == PlotOrientation.VERTICAL ?
+                        mouseY > entityBounds.getCenterY():
+                        mouseX < entityBounds.getCenterX();
+                y = snapRangeToStart ?
+                        intervalDataset.getStartY(entity.getSeriesIndex(), entity.getItem()) :
+                        intervalDataset.getEndY(entity.getSeriesIndex(), entity.getItem());
+            }
+            return new Point2DNumber(x, y);
+        } else {
+            return new Point2DNumber(
+                    dataset.getX(entity.getSeriesIndex(), entity.getItem()),
+                    dataset.getY(entity.getSeriesIndex(), entity.getItem()));
+        }
+    }
+
+    /**
+     * This method is called when a measurement has been made by the user. This
+     * method adds an annotation to the {@code plot}.
+     * 
+     * @param plot   the plot for the annotation
+     * @param first  the first measurement point
+     * @param second the second measurement point
+     * @param event  the mouse event of the second mouse click.
+     */
+    protected void addAnnotation(XYPlot plot, Point2DNumber first,
+            Point2DNumber second, MouseEvent event) {
+        String label;
+        XYMeasurementAnnotation.Orientation orientation;
+        if (measurementAxis == MeasurementAxis.DOMAIN) {
+            label = createMeasurementLabel(first.getX(), second.getX(), event);
+            orientation = plot.getOrientation() == PlotOrientation.VERTICAL
+                    ? Orientation.HORIZONTAL
+                    : Orientation.VERTICAL;
+        } else {
+            label = createMeasurementLabel(first.getY(), second.getY(), event);
+            orientation = plot.getOrientation() == PlotOrientation.VERTICAL
+                    ? Orientation.VERTICAL
+                    : Orientation.HORIZONTAL;
+        }
+        plot.addAnnotation(
+                createMeasurementAnnotation(orientation, label, first, second));
+    }
+
+    /**
+     * Creates a label for a measurement. By default this call is delegated to
+     * the {@link #setAnnotationLabelProvider(BiFunction) label provider}.
+     * 
+     * @param firstValue  the first measurement value
+     * @param secondValue the second measurement value
+     * @param event       the mouse event of the second mouse click.
+     * @return the label to put use for the measurement annotation, should not
+     *         be {@code null}.
+     */
+    protected String createMeasurementLabel(Number firstValue,
+            Number secondValue, MouseEvent event) {
+        return annotationLabelProvider.apply(firstValue, secondValue);
+    }
+
+    /**
+     * Creates an annotation for a measurement. By default an
+     * {@link XYMeasurementAnnotation} will be created.
+     * 
+     * @param orientation orientation to use for the
+     *                    {@link XYMeasurementAnnotation}
+     * @param label       the annotation text
+     * @param first       the first measurement point
+     * @param second      the second measurement point
+     * @return the created measurement annotation
+     */
+    protected XYAnnotation createMeasurementAnnotation(
+            XYMeasurementAnnotation.Orientation orientation, String label,
+            Point2DNumber first, Point2DNumber second) {
+        return new XYMeasurementAnnotation(orientation, label, first, second);
+    }
+}


### PR DESCRIPTION
This pull request allows a user to create measurements in XYPlots. A user starts a measurement using Alt-Mouse-Click (configurable). A second Alt-Mouse-Click adds an annotation to the plot, see screenshot below.
![XYMeasureWithAnnotations](https://user-images.githubusercontent.com/72129129/118269074-8a2e2d00-b4be-11eb-806e-8c85471bd874.png)
