### PR TITLE
Option to truncate item labels and compute contrast item label color

### DIFF
--- a/src/main/java/org/jfree/chart/ChartColor.java
+++ b/src/main/java/org/jfree/chart/ChartColor.java
@@ -31,6 +31,7 @@
  *
  * Original Author:  Cameron Riley;
  * Contributor(s):   David Gilbert (for Object Refinery Limited);
+ *                   Yuri Blankenstein;
  *
  */
 
@@ -136,10 +137,21 @@ public class ChartColor extends Color {
      * {@code ChartColor} objects.
      *
      * @return An array of objects with the {@code Paint} interface.
+     * @see #createDefaultColorArray()
      */
     public static Paint[] createDefaultPaintArray() {
-
-        return new Paint[] {
+        return createDefaultColorArray();
+    }
+    
+    /**
+     * Convenience method to return an array of {@code Color} objects that
+     * represent the pre-defined colors in the {@code Color} and
+     * {@code ChartColor} objects.
+     *
+     * @return An array of objects with the {@code Color} interface.
+     */
+    public static Color[] createDefaultColorArray() {
+        return new Color[] {
             new Color(0xFF, 0x55, 0x55),
             new Color(0x55, 0x55, 0xFF),
             new Color(0x55, 0xFF, 0x55),
@@ -177,4 +189,41 @@ public class ChartColor extends Color {
         };
     }
 
+    /**
+     * Creates an array of {@link Color#darker() darker} {@code colors} to use
+     * for e.g. borders.
+     * 
+     * @param colors original colors
+     * @return a new array containing {@link Color#darker() darker} instances of
+     *         the original colors.
+     */
+    public static Color[] createDarkerColorArray(Color[] colors) {
+        final Color[] result = new Color[colors.length];
+        for (int i = 0; i < colors.length; i++) {
+            result[i] = colors[i].darker();
+        }
+        return result;
+    }
+
+    /**
+     * Returns either {@link Color#BLACK black} or {@link Color#WHITE white},
+     * depending on the provided {@code color} to achieve the best contrast for
+     * e.g. text labels.<br>
+     * The {@code color} is
+     * <a href="https://en.wikipedia.org/wiki/YIQ#From_RGB_to_YIQ">converted
+     * from RGB to YIQ</a> and the luminance value (Y; &#8776;[0 .. 255]) is
+     * used to determine if {@code color} is closer to either {@link Color#BLACK
+     * black} or {@link Color#WHITE white}.
+     * 
+     * @param color the color for which the contrasted color is computed
+     * @return either {@link Color#BLACK black} or {@link Color#WHITE white},
+     *         depending on {@code color}
+     */
+    public static Color getContrastColor(Color color) {
+        // From Wikipedia: The Y component represents the luma information, and
+        // is the only component used by black-and-white television receivers.
+        final double luminanceY = 0.299 * color.getRed()
+                + 0.587 * color.getGreen() + 0.114 * color.getBlue();
+        return luminanceY >= 128 ? Color.BLACK : Color.WHITE;
+    }
 }

--- a/src/main/java/org/jfree/chart/labels/ItemLabelAnchor.java
+++ b/src/main/java/org/jfree/chart/labels/ItemLabelAnchor.java
@@ -161,6 +161,28 @@ public final class ItemLabelAnchor implements Serializable {
     }
 
     /**
+     * Returns {@code true} if this anchor point is inside an area.
+     *
+     * @return {@code true} if this anchor point is inside an area,
+     *         {@code false} otherwise.
+     */
+    public boolean isInternal() {
+        return this == ItemLabelAnchor.CENTER
+               || this == ItemLabelAnchor.INSIDE1
+               || this == ItemLabelAnchor.INSIDE2
+               || this == ItemLabelAnchor.INSIDE3
+               || this == ItemLabelAnchor.INSIDE4
+               || this == ItemLabelAnchor.INSIDE5
+               || this == ItemLabelAnchor.INSIDE6
+               || this == ItemLabelAnchor.INSIDE7
+               || this == ItemLabelAnchor.INSIDE8
+               || this == ItemLabelAnchor.INSIDE9
+               || this == ItemLabelAnchor.INSIDE10
+               || this == ItemLabelAnchor.INSIDE11
+               || this == ItemLabelAnchor.INSIDE12;
+    }
+
+    /**
      * Returns a string representing the object.
      *
      * @return The string.

--- a/src/main/java/org/jfree/chart/labels/ItemLabelClip.java
+++ b/src/main/java/org/jfree/chart/labels/ItemLabelClip.java
@@ -1,0 +1,19 @@
+package org.jfree.chart.labels;
+
+/**
+ * The clip type for the label. Only used when
+ * {@link ItemLabelAnchor#isInternal()} returns {@code true}, if {@code false}
+ * {@code labelClip} is always considered to be {@link ItemLabelClip#NONE})
+ */
+public enum ItemLabelClip {
+    /** Only draw label when it fits the item */
+    FIT,
+    /** No clipping, labels might overlap */
+    NONE,
+    /** Does not draw outside the item, just clips the label */
+    CLIP,
+    /** Truncates the label with '...' to fit the item */
+    TRUNCATE,
+    /** Truncates the label on whole words with '...' to fit the item */
+    TRUNCATE_WORD
+}

--- a/src/main/java/org/jfree/chart/labels/ItemLabelPosition.java
+++ b/src/main/java/org/jfree/chart/labels/ItemLabelPosition.java
@@ -30,7 +30,7 @@
  * (C) Copyright 2003-2020, by Object Refinery Limited and Contributors.
  *
  * Original Author:  David Gilbert (for Object Refinery Limited);
- * Contributor(s):   -;
+ * Contributor(s):   Yuri Blankenstein;
  *
  */
 
@@ -60,6 +60,9 @@ public class ItemLabelPosition implements Serializable {
 
     /** The rotation angle. */
     private double angle;
+    
+    /** The item label clip type. */
+    private ItemLabelClip itemLabelClip;
 
     /**
      * Creates a new position record with default settings.
@@ -82,6 +85,27 @@ public class ItemLabelPosition implements Serializable {
     }
 
     /**
+     * Creates a new position record. The item label anchor is a point relative
+     * to the data item (dot, bar or other visual item) on a chart. The item
+     * label is aligned by aligning the text anchor with the item label anchor.
+     *
+     * @param itemLabelAnchor the item label anchor ({@code null} not
+     *                        permitted).
+     * @param textAnchor      the text anchor ({@code null} not permitted).
+     * @param itemLabelClip   The clip type for the label ({@code null} not
+     *                        permitted. Only used when
+     *                        {@link ItemLabelAnchor#isInternal()} returns
+     *                        {@code true}, if {@code false} {@code labelClip}
+     *                        is always considered to be
+     *                        {@link ItemLabelClip#NONE})
+     */
+    public ItemLabelPosition(ItemLabelAnchor itemLabelAnchor,
+            TextAnchor textAnchor, ItemLabelClip itemLabelClip) {
+        this(itemLabelAnchor, textAnchor, TextAnchor.CENTER, 0.0,
+                itemLabelClip);
+    }
+    
+    /**
      * Creates a new position record.  The item label anchor is a point
      * relative to the data item (dot, bar or other visual item) on a chart.
      * The item label is aligned by aligning the text anchor with the
@@ -94,16 +118,43 @@ public class ItemLabelPosition implements Serializable {
      *                        permitted).
      * @param angle  the rotation angle (in radians).
      */
-    public ItemLabelPosition(ItemLabelAnchor itemLabelAnchor, 
+    public ItemLabelPosition(ItemLabelAnchor itemLabelAnchor,
             TextAnchor textAnchor, TextAnchor rotationAnchor, double angle) {
+        this(itemLabelAnchor, textAnchor, rotationAnchor, angle,
+                ItemLabelClip.FIT);
+
+    }
+
+    /**
+     * Creates a new position record. The item label anchor is a point relative
+     * to the data item (dot, bar or other visual item) on a chart. The item
+     * label is aligned by aligning the text anchor with the item label anchor.
+     *
+     * @param itemLabelAnchor the item label anchor ({@code null} not
+     *                        permitted).
+     * @param textAnchor      the text anchor ({@code null} not permitted).
+     * @param rotationAnchor  the rotation anchor ({@code null} not permitted).
+     * @param angle           the rotation angle (in radians).
+     * @param itemLabelClip   The clip type for the label ({@code null} not
+     *                        permitted. Only used when
+     *                        {@link ItemLabelAnchor#isInternal()} returns
+     *                        {@code true}, if {@code false} {@code labelClip}
+     *                        is always considered to be
+     *                        {@link ItemLabelClip#NONE})
+     */
+    public ItemLabelPosition(ItemLabelAnchor itemLabelAnchor,
+            TextAnchor textAnchor, TextAnchor rotationAnchor, double angle,
+            ItemLabelClip itemLabelClip) {
 
         Args.nullNotPermitted(itemLabelAnchor, "itemLabelAnchor");
         Args.nullNotPermitted(textAnchor, "textAnchor");
         Args.nullNotPermitted(rotationAnchor, "rotationAnchor");
+        Args.nullNotPermitted(itemLabelClip, "labelClip");
         this.itemLabelAnchor = itemLabelAnchor;
         this.textAnchor = textAnchor;
         this.rotationAnchor = rotationAnchor;
         this.angle = angle;
+        this.itemLabelClip = itemLabelClip;
     }
 
     /**
@@ -141,6 +192,15 @@ public class ItemLabelPosition implements Serializable {
     public double getAngle() {
         return this.angle;
     }
+    
+    /**
+     * Returns the clip type for the label.
+     * 
+     * @return The clip type for the label.
+     */
+    public ItemLabelClip getItemLabelClip() {
+		return this.itemLabelClip;
+	}
 
     /**
      * Tests this object for equality with an arbitrary object.
@@ -168,6 +228,9 @@ public class ItemLabelPosition implements Serializable {
             return false;
         }
         if (this.angle != that.angle) {
+            return false;
+        }
+        if (!this.itemLabelClip.equals(that.itemLabelClip)) {
             return false;
         }
         return true;

--- a/src/main/java/org/jfree/chart/renderer/category/BarRenderer.java
+++ b/src/main/java/org/jfree/chart/renderer/category/BarRenderer.java
@@ -1054,7 +1054,7 @@ public class BarRenderer extends AbstractCategoryItemRenderer
         Point2D anchorPoint = calculateLabelAnchorPoint(
                 position.getItemLabelAnchor(), bar, plot.getOrientation());
 
-        if (isInternalAnchor(position.getItemLabelAnchor())) {
+        if (position.getItemLabelAnchor().isInternal()) {
             Shape bounds = TextUtils.calculateRotatedStringBounds(label,
                     g2, (float) anchorPoint.getX(), (float) anchorPoint.getY(),
                     position.getTextAnchor(), position.getAngle(),
@@ -1195,29 +1195,6 @@ public class BarRenderer extends AbstractCategoryItemRenderer
 
         return result;
 
-    }
-
-    /**
-     * Returns {@code true} if the specified anchor point is inside a bar.
-     *
-     * @param anchor  the anchor point.
-     *
-     * @return A boolean.
-     */
-    private boolean isInternalAnchor(ItemLabelAnchor anchor) {
-        return anchor == ItemLabelAnchor.CENTER
-               || anchor == ItemLabelAnchor.INSIDE1
-               || anchor == ItemLabelAnchor.INSIDE2
-               || anchor == ItemLabelAnchor.INSIDE3
-               || anchor == ItemLabelAnchor.INSIDE4
-               || anchor == ItemLabelAnchor.INSIDE5
-               || anchor == ItemLabelAnchor.INSIDE6
-               || anchor == ItemLabelAnchor.INSIDE7
-               || anchor == ItemLabelAnchor.INSIDE8
-               || anchor == ItemLabelAnchor.INSIDE9
-               || anchor == ItemLabelAnchor.INSIDE10
-               || anchor == ItemLabelAnchor.INSIDE11
-               || anchor == ItemLabelAnchor.INSIDE12;
     }
 
     /**

--- a/src/main/java/org/jfree/chart/renderer/xy/XYBarRenderer.java
+++ b/src/main/java/org/jfree/chart/renderer/xy/XYBarRenderer.java
@@ -35,11 +35,13 @@
  *                   Bill Kelemen;
  *                   Marc van Glabbeek (bug 1775452);
  *                   Richard West, Advanced Micro Devices, Inc.;
+ *                   Yuri Blankenstein;
  *
  */
 
 package org.jfree.chart.renderer.xy;
 
+import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.Graphics2D;
 import java.awt.Paint;
@@ -68,6 +70,7 @@ import org.jfree.chart.plot.XYPlot;
 import org.jfree.chart.text.TextUtils;
 import org.jfree.chart.ui.GradientPaintTransformer;
 import org.jfree.chart.ui.RectangleEdge;
+import org.jfree.chart.ui.RectangleInsets;
 import org.jfree.chart.ui.StandardGradientPaintTransformer;
 import org.jfree.chart.util.ObjectUtils;
 import org.jfree.chart.util.Args;
@@ -243,6 +246,12 @@ public class XYBarRenderer extends AbstractXYItemRenderer
      */
     private double barAlignmentFactor;
 
+    /** The minimum size for the bar to draw a label */
+    private Dimension minimumLabelSize;
+    
+    /** {@code true} if the label should be aligned to the visible part of the bar. */
+    private boolean showLabelInsideVisibleBar;
+        
     /**
      * The default constructor.
      */
@@ -584,6 +593,51 @@ public class XYBarRenderer extends AbstractXYItemRenderer
     }
 
     /**
+     * Returns the minimum size for the bar to draw a label.
+     * 
+     * @return The minimum size to draw a label.
+     */
+    public Dimension getMinimumLabelSize() {
+        return minimumLabelSize;
+    }
+
+    /**
+     * Sets the minimum size for the bar to draw a label.
+     * 
+     * @param minimumLabelSize The size
+     */
+    public void setMinimumLabelSize(Dimension minimumLabelSize) {
+        this.minimumLabelSize = minimumLabelSize;
+        fireChangeEvent();
+    }
+
+    /**
+     * Returns {@code true} if the label should be aligned to the visible part
+     * of the bar.
+     * 
+     * @return {@code true} if the label should be aligned to the visible part
+     *         of the bar.
+     * @see #setShowLabelInsideVisibleBar(boolean)
+     */
+    public boolean isShowLabelInsideVisibleBar() {
+        return showLabelInsideVisibleBar;
+    }
+    
+    /**
+     * Sets whether the label should be aligned to the visible part of the
+     * bar.<br>
+     * This setting has no effect when {@link ItemLabelAnchor#isInternal()}
+     * returns {@code false}.
+     * 
+     * @param showLabelInsideVisibleBar {@code true} to align to the visible
+     *                                  part.
+     */
+    public void setShowLabelInsideVisibleBar(boolean showLabelInsideVisibleBar) {
+        this.showLabelInsideVisibleBar = showLabelInsideVisibleBar;
+        fireChangeEvent();
+    }
+    
+    /**
      * Initialises the renderer and returns a state object that should be
      * passed to all subsequent calls to the drawItem() method.  Here we
      * calculate the Java2D y-coordinate for zero, since all the bars have
@@ -846,7 +900,7 @@ public class XYBarRenderer extends AbstractXYItemRenderer
      * double, double, boolean)} so that the bar can be used to calculate the
      * label anchor point.
      *
-     * @param g2  the graphics device.
+     * @param g  the graphics device.
      * @param dataset  the dataset.
      * @param series  the series index.
      * @param item  the item index.
@@ -856,7 +910,7 @@ public class XYBarRenderer extends AbstractXYItemRenderer
      * @param bar  the bar.
      * @param negative  a flag indicating a negative value.
      */
-    protected void drawItemLabel(Graphics2D g2, XYDataset dataset,
+    protected void drawItemLabel(Graphics2D g, XYDataset dataset,
             int series, int item, XYPlot plot, XYItemLabelGenerator generator,
             Rectangle2D bar, boolean negative) {
 
@@ -868,6 +922,7 @@ public class XYBarRenderer extends AbstractXYItemRenderer
             return;  // nothing to do
         }
 
+        Graphics2D g2 = (Graphics2D) g.create();
         Font labelFont = getItemLabelFont(series, item);
         g2.setFont(labelFont);
         Paint paint = getItemLabelPaint(series, item);
@@ -881,45 +936,164 @@ public class XYBarRenderer extends AbstractXYItemRenderer
             position = getNegativeItemLabelPosition(series, item);
         }
 
-        // work out the label anchor point...
-        Point2D anchorPoint = calculateLabelAnchorPoint(
-                position.getItemLabelAnchor(), bar, plot.getOrientation());
+        Rectangle2D drawBar = bar;
 
-        if (isInternalAnchor(position.getItemLabelAnchor())) {
-            Shape bounds = TextUtils.calculateRotatedStringBounds(label,
-                    g2, (float) anchorPoint.getX(), (float) anchorPoint.getY(),
-                    position.getTextAnchor(), position.getAngle(),
-                    position.getRotationAnchor());
-
-            if (bounds != null) {
-                if (!bar.contains(bounds.getBounds2D())) {
-                    if (!negative) {
-                        position = getPositiveItemLabelPositionFallback();
-                    }
-                    else {
-                        position = getNegativeItemLabelPositionFallback();
-                    }
-                    if (position != null) {
-                        anchorPoint = calculateLabelAnchorPoint(
-                                position.getItemLabelAnchor(), bar,
-                                plot.getOrientation());
-                    }
-                }
+        if (position.getItemLabelAnchor().isInternal()) {
+            if (showLabelInsideVisibleBar && g2.getClipBounds() != null) {
+                drawBar = drawBar.createIntersection(g2.getClipBounds().getBounds2D());
             }
-
+            
+            Rectangle2D labelBar = getItemLabelInsets().createInsetRectangle(drawBar);
+            if (minimumLabelSize != null && 
+                    (labelBar.getWidth() < minimumLabelSize.getWidth()
+                    || labelBar.getHeight() < minimumLabelSize.getHeight())) {
+                return; // nothing to do
+            }
         }
 
-        if (position != null) {
-            TextUtils.drawRotatedString(label, g2,
+        // work out the label anchor point...
+        Point2D anchorPoint = calculateLabelAnchorPoint(
+                position.getItemLabelAnchor(), drawBar, plot.getOrientation());
+
+        String drawLabel = calculateLabeltoDraw(
+                label, anchorPoint, position, drawBar, g2);
+        
+        if (drawLabel == null) {
+            if (!negative) {
+                position = getPositiveItemLabelPositionFallback();
+            } else {
+                position = getNegativeItemLabelPositionFallback();
+            }
+            if (position != null) {
+                g2 = (Graphics2D) g.create();
+                g2.setFont(labelFont);
+                g2.setPaint(paint);
+
+                if (position.getItemLabelAnchor().isInternal()) {
+                    if (showLabelInsideVisibleBar && g2.getClipBounds() != null) {
+                        drawBar = drawBar.createIntersection(g2.getClipBounds().getBounds2D());
+                    }
+                    
+                    Rectangle2D labelBar = getItemLabelInsets().createInsetRectangle(drawBar);
+                    if (minimumLabelSize != null && 
+                            (labelBar.getWidth() < minimumLabelSize.getWidth()
+                            || labelBar.getHeight() < minimumLabelSize.getHeight())) {
+                        return; // nothing to do
+                    }
+                }
+
+                anchorPoint = calculateLabelAnchorPoint(
+                        position.getItemLabelAnchor(), drawBar, plot.getOrientation());
+                
+                drawLabel = calculateLabeltoDraw(
+                        label, anchorPoint, position, drawBar, g2);
+            }
+        }
+        
+        if (drawLabel != null) {
+            TextUtils.drawRotatedString(drawLabel, g2,
                     (float) anchorPoint.getX(), (float) anchorPoint.getY(),
                     position.getTextAnchor(), position.getAngle(),
                     position.getRotationAnchor());
         }
     }
+    
+    /**
+     * @return The label to draw or {@code null} if label should not be drawn.
+     */
+    private String calculateLabeltoDraw(String label, Point2D anchorPoint,
+            ItemLabelPosition position, Rectangle2D bar, Graphics2D g2) {
+        if (!position.getItemLabelAnchor().isInternal()) {
+            return label;
+        }
+        
+        // Taking the bounds of the bounds will ceil the rectangle to its
+        // smallest enclosing integer instance, this avoid rounding errors when
+        // testing if the label fits
+        Rectangle2D labelBar = getItemLabelInsets().createInsetRectangle(bar).getBounds();
+        
+        switch (position.getItemLabelClip()) {
+            case CLIP :
+                Shape currentClip = g2.getClip();
+                if (currentClip == null) {
+                    g2.setClip(labelBar);
+                } else {
+                    g2.setClip(labelBar
+                            .createIntersection(currentClip.getBounds2D()));
+                }
+                return label;
+            case NONE :
+                return label;
+            default :
+        }
+
+        String result = label;
+        while (result != null) {
+            Shape bounds = TextUtils.calculateRotatedStringBounds(result,
+                    g2, (float) anchorPoint.getX(), (float) anchorPoint.getY(),
+                    position.getTextAnchor(), position.getAngle(),
+                    position.getRotationAnchor());
+            Rectangle2D bounds2D = bounds == null ? null : bounds.getBounds2D();
+
+            if (bounds2D != null && labelBar.contains(bounds2D)) {
+                // Label fits
+                return result;
+            } else if (bounds2D != null && labelBar.getHeight() < bounds2D.getHeight()) {
+                // Label will never fit, insufficient height
+                return null;
+            } else {
+                switch (position.getItemLabelClip()) {
+                    case FIT :
+                        return null;
+                    case TRUNCATE : {
+                        String nextResult = result.replaceFirst(".(\\.{3})?$",
+                                "...");
+                        if ("...".equals(nextResult) || result.equals(nextResult)) {
+                            return null;
+                        } else {
+                            result = nextResult;
+                        }
+                        break;
+                    }
+                    case TRUNCATE_WORD : {
+                        String nextResult = result 
+                                .replaceFirst("\\W+\\w*(\\.{3})?$", "...");
+                        if ("...".equals(nextResult) || result.equals(nextResult)) {
+                            return null;
+                        } else {
+                            result = nextResult;
+                        }
+                        break;
+                    }
+                    default :
+                        throw new IllegalStateException("Should never happen");
+                }
+            }
+        }
+        return null;
+    }
 
     /**
      * Calculates the item label anchor point.
      *
+     * <pre>
+     * Inside:
+     *  +-----------------+
+     *  | 10/11  12   1/2 |
+     *  |   9     C    3  |
+     *  |  7/8    6   4/5 |
+     *  +-----------------+
+
+     * Outside:
+     * 10/11       12         1/2
+     *     +----------------+
+     *     |                |
+     *   9 |                |  3
+     *     |                |
+     *     +----------------+
+     *  7/8        6          4/5 
+     * </pre>
+     * 
      * @param anchor  the anchor.
      * @param bar  the bar.
      * @param orientation  the plot orientation.
@@ -930,124 +1104,48 @@ public class XYBarRenderer extends AbstractXYItemRenderer
             Rectangle2D bar, PlotOrientation orientation) {
 
         Point2D result = null;
-        double offset = getItemLabelAnchorOffset();
-        double x0 = bar.getX() - offset;
-        double x1 = bar.getX();
-        double x2 = bar.getX() + offset;
-        double x3 = bar.getCenterX();
-        double x4 = bar.getMaxX() - offset;
-        double x5 = bar.getMaxX();
-        double x6 = bar.getMaxX() + offset;
-
-        double y0 = bar.getMaxY() + offset;
-        double y1 = bar.getMaxY();
-        double y2 = bar.getMaxY() - offset;
-        double y3 = bar.getCenterY();
-        double y4 = bar.getMinY() + offset;
-        double y5 = bar.getMinY();
-        double y6 = bar.getMinY() - offset;
+        RectangleInsets labelInsets = getItemLabelInsets();
+        Rectangle2D insideBar = labelInsets.createInsetRectangle(bar);
+        Rectangle2D outsideBar = labelInsets.createOutsetRectangle(bar);
 
         if (anchor == ItemLabelAnchor.CENTER) {
-            result = new Point2D.Double(x3, y3);
-        }
-        else if (anchor == ItemLabelAnchor.INSIDE1) {
-            result = new Point2D.Double(x4, y4);
-        }
-        else if (anchor == ItemLabelAnchor.INSIDE2) {
-            result = new Point2D.Double(x4, y4);
-        }
-        else if (anchor == ItemLabelAnchor.INSIDE3) {
-            result = new Point2D.Double(x4, y3);
-        }
-        else if (anchor == ItemLabelAnchor.INSIDE4) {
-            result = new Point2D.Double(x4, y2);
-        }
-        else if (anchor == ItemLabelAnchor.INSIDE5) {
-            result = new Point2D.Double(x4, y2);
-        }
-        else if (anchor == ItemLabelAnchor.INSIDE6) {
-            result = new Point2D.Double(x3, y2);
-        }
-        else if (anchor == ItemLabelAnchor.INSIDE7) {
-            result = new Point2D.Double(x2, y2);
-        }
-        else if (anchor == ItemLabelAnchor.INSIDE8) {
-            result = new Point2D.Double(x2, y2);
-        }
-        else if (anchor == ItemLabelAnchor.INSIDE9) {
-            result = new Point2D.Double(x2, y3);
-        }
-        else if (anchor == ItemLabelAnchor.INSIDE10) {
-            result = new Point2D.Double(x2, y4);
-        }
-        else if (anchor == ItemLabelAnchor.INSIDE11) {
-            result = new Point2D.Double(x2, y4);
-        }
-        else if (anchor == ItemLabelAnchor.INSIDE12) {
-            result = new Point2D.Double(x3, y4);
-        }
-        else if (anchor == ItemLabelAnchor.OUTSIDE1) {
-            result = new Point2D.Double(x5, y6);
-        }
-        else if (anchor == ItemLabelAnchor.OUTSIDE2) {
-            result = new Point2D.Double(x6, y5);
-        }
-        else if (anchor == ItemLabelAnchor.OUTSIDE3) {
-            result = new Point2D.Double(x6, y3);
-        }
-        else if (anchor == ItemLabelAnchor.OUTSIDE4) {
-            result = new Point2D.Double(x6, y1);
-        }
-        else if (anchor == ItemLabelAnchor.OUTSIDE5) {
-            result = new Point2D.Double(x5, y0);
-        }
-        else if (anchor == ItemLabelAnchor.OUTSIDE6) {
-            result = new Point2D.Double(x3, y0);
-        }
-        else if (anchor == ItemLabelAnchor.OUTSIDE7) {
-            result = new Point2D.Double(x1, y0);
-        }
-        else if (anchor == ItemLabelAnchor.OUTSIDE8) {
-            result = new Point2D.Double(x0, y1);
-        }
-        else if (anchor == ItemLabelAnchor.OUTSIDE9) {
-            result = new Point2D.Double(x0, y3);
-        }
-        else if (anchor == ItemLabelAnchor.OUTSIDE10) {
-            result = new Point2D.Double(x0, y5);
-        }
-        else if (anchor == ItemLabelAnchor.OUTSIDE11) {
-            result = new Point2D.Double(x1, y6);
-        }
-        else if (anchor == ItemLabelAnchor.OUTSIDE12) {
-            result = new Point2D.Double(x3, y6);
+            result = new Point2D.Double(bar.getCenterX(), bar.getCenterY());
+        } else if (anchor == ItemLabelAnchor.INSIDE1 || anchor == ItemLabelAnchor.INSIDE2) {
+            result = new Point2D.Double(insideBar.getMaxX(), insideBar.getMinY());
+        } else if (anchor == ItemLabelAnchor.INSIDE3) {
+            result = new Point2D.Double(insideBar.getMaxX(), bar.getCenterY());
+        } else if (anchor == ItemLabelAnchor.INSIDE4 || anchor == ItemLabelAnchor.INSIDE5) {
+            result = new Point2D.Double(insideBar.getMaxX(), insideBar.getMaxY());
+        } else if (anchor == ItemLabelAnchor.INSIDE6) {
+            result = new Point2D.Double(bar.getCenterX(), insideBar.getMaxY());
+        } else if (anchor == ItemLabelAnchor.INSIDE7 || anchor == ItemLabelAnchor.INSIDE8) {
+            result = new Point2D.Double(insideBar.getMinX(), insideBar.getMaxY());
+        } else if (anchor == ItemLabelAnchor.INSIDE9) {
+            result = new Point2D.Double(insideBar.getMinX(), bar.getCenterY());
+        } else if (anchor == ItemLabelAnchor.INSIDE10 || anchor == ItemLabelAnchor.INSIDE11) {
+            result = new Point2D.Double(insideBar.getMinX(), insideBar.getMinY());
+        } else if (anchor == ItemLabelAnchor.INSIDE12) {
+            result = new Point2D.Double(bar.getCenterX(), insideBar.getMinY());
+        } else if (anchor == ItemLabelAnchor.OUTSIDE1 || anchor == ItemLabelAnchor.OUTSIDE2) {
+            result = new Point2D.Double(outsideBar.getMaxX(), outsideBar.getMinY());
+        } else if (anchor == ItemLabelAnchor.OUTSIDE3) {
+            result = new Point2D.Double(outsideBar.getMaxX(), bar.getCenterY());
+        } else if (anchor == ItemLabelAnchor.OUTSIDE4 || anchor == ItemLabelAnchor.OUTSIDE5) {
+            result = new Point2D.Double(outsideBar.getMaxX(), outsideBar.getMaxY());
+        } else if (anchor == ItemLabelAnchor.OUTSIDE6) {
+            result = new Point2D.Double(bar.getCenterX(), outsideBar.getMaxY());
+        } else if (anchor == ItemLabelAnchor.OUTSIDE7 || anchor == ItemLabelAnchor.OUTSIDE8) {
+            result = new Point2D.Double(outsideBar.getMinX(), outsideBar.getMaxY());
+        } else if (anchor == ItemLabelAnchor.OUTSIDE9) {
+            result = new Point2D.Double(outsideBar.getMinX(), bar.getCenterY());
+        } else if (anchor == ItemLabelAnchor.OUTSIDE10 || anchor == ItemLabelAnchor.OUTSIDE11) {
+            result = new Point2D.Double(outsideBar.getMinX(), outsideBar.getMinY());
+        } else if (anchor == ItemLabelAnchor.OUTSIDE12) {
+            result = new Point2D.Double(bar.getCenterX(), outsideBar.getMinY());
         }
 
         return result;
 
-    }
-
-    /**
-     * Returns {@code true} if the specified anchor point is inside a bar.
-     *
-     * @param anchor  the anchor point.
-     *
-     * @return A boolean.
-     */
-    private boolean isInternalAnchor(ItemLabelAnchor anchor) {
-        return anchor == ItemLabelAnchor.CENTER
-               || anchor == ItemLabelAnchor.INSIDE1
-               || anchor == ItemLabelAnchor.INSIDE2
-               || anchor == ItemLabelAnchor.INSIDE3
-               || anchor == ItemLabelAnchor.INSIDE4
-               || anchor == ItemLabelAnchor.INSIDE5
-               || anchor == ItemLabelAnchor.INSIDE6
-               || anchor == ItemLabelAnchor.INSIDE7
-               || anchor == ItemLabelAnchor.INSIDE8
-               || anchor == ItemLabelAnchor.INSIDE9
-               || anchor == ItemLabelAnchor.INSIDE10
-               || anchor == ItemLabelAnchor.INSIDE11
-               || anchor == ItemLabelAnchor.INSIDE12;
     }
 
     /**


### PR DESCRIPTION
I've added an option to clip labels when rendered inside a bar, see XYBarRenderer. Different clip options are available, see ItemLabelClip. 
I also added an option to compute the item label color based on the item color, to automatically use a contrasting color.