### PR TITLE
Offline rendering for charts with large datasets

### DIFF
--- a/src/main/java/org/jfree/chart/ChartPanel.java
+++ b/src/main/java/org/jfree/chart/ChartPanel.java
@@ -45,6 +45,7 @@
  *                   Alessandro Borges - patch 1460845;
  *                   Martin Hoeller;
  *                   Simon Legner - patch from bug 1129;
+ *                   Yuri Blankenstein;
  */
 
 package org.jfree.chart;
@@ -58,7 +59,6 @@ import java.awt.Dimension;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.GraphicsConfiguration;
-import java.awt.Image;
 import java.awt.Insets;
 import java.awt.Paint;
 import java.awt.Point;
@@ -76,6 +76,7 @@ import java.awt.geom.AffineTransform;
 import java.awt.geom.Line2D;
 import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
+import java.awt.image.BufferedImage;
 import java.awt.print.PageFormat;
 import java.awt.print.Printable;
 import java.awt.print.PrinterException;
@@ -114,9 +115,9 @@ import org.jfree.chart.event.ChartChangeEvent;
 import org.jfree.chart.event.ChartChangeListener;
 import org.jfree.chart.event.ChartProgressEvent;
 import org.jfree.chart.event.ChartProgressListener;
-import org.jfree.chart.panel.Overlay;
 import org.jfree.chart.event.OverlayChangeEvent;
 import org.jfree.chart.event.OverlayChangeListener;
+import org.jfree.chart.panel.Overlay;
 import org.jfree.chart.plot.Pannable;
 import org.jfree.chart.plot.Plot;
 import org.jfree.chart.plot.PlotOrientation;
@@ -232,13 +233,7 @@ public class ChartPanel extends JPanel implements ChartChangeListener,
     private boolean refreshBuffer;
 
     /** A buffer for the rendered chart. */
-    private transient Image chartBuffer;
-
-    /** The height of the chart buffer. */
-    private int chartBufferHeight;
-
-    /** The width of the chart buffer. */
-    private int chartBufferWidth;
+    private transient BufferedImage chartBuffer;
 
     /**
      * The minimum width for drawing a chart (uses scaling for smaller widths).
@@ -1357,106 +1352,57 @@ public class ChartPanel extends JPanel implements ChartChangeListener,
         // first determine the size of the chart rendering area...
         Dimension size = getSize();
         Insets insets = getInsets();
-        Rectangle2D available = new Rectangle2D.Double(insets.left, insets.top,
-                size.getWidth() - insets.left - insets.right,
-                size.getHeight() - insets.top - insets.bottom);
+        final int availableWidth = size.width - insets.left - insets.right; 
+        final int availableHeight = size.height - insets.top - insets.bottom;
 
         // work out if scaling is required...
         boolean scale = false;
-        double drawWidth = available.getWidth();
-        double drawHeight = available.getHeight();
+        int drawWidth = availableWidth;
+        int drawHeight = availableHeight;
         this.scaleX = 1.0;
         this.scaleY = 1.0;
 
         if (drawWidth < this.minimumDrawWidth) {
-            this.scaleX = drawWidth / this.minimumDrawWidth;
+            this.scaleX = (double) drawWidth / (double) this.minimumDrawWidth;
             drawWidth = this.minimumDrawWidth;
             scale = true;
         }
         else if (drawWidth > this.maximumDrawWidth) {
-            this.scaleX = drawWidth / this.maximumDrawWidth;
+            this.scaleX = (double) drawWidth / (double) this.maximumDrawWidth;
             drawWidth = this.maximumDrawWidth;
             scale = true;
         }
 
         if (drawHeight < this.minimumDrawHeight) {
-            this.scaleY = drawHeight / this.minimumDrawHeight;
+            this.scaleY = (double) drawHeight / (double) this.minimumDrawHeight;
             drawHeight = this.minimumDrawHeight;
             scale = true;
         }
         else if (drawHeight > this.maximumDrawHeight) {
-            this.scaleY = drawHeight / this.maximumDrawHeight;
+            this.scaleY = (double) drawHeight / (double) this.maximumDrawHeight;
             drawHeight = this.maximumDrawHeight;
             scale = true;
         }
 
-        Rectangle2D chartArea = new Rectangle2D.Double(0.0, 0.0, drawWidth,
-                drawHeight);
+        Dimension chartSize = new Dimension(drawWidth, drawHeight);
 
         // are we using the chart buffer?
         if (this.useBuffer) {
 
-            // for better rendering on the HiDPI monitors upscaling the buffer to the "native" resoution
+            // for better rendering on the HiDPI monitors upscaling the buffer to the "native" resolution
             // instead of using logical one provided by Swing
             final AffineTransform globalTransform = ((Graphics2D) g).getTransform();
             final double globalScaleX = globalTransform.getScaleX();
             final double globalScaleY = globalTransform.getScaleY();
 
-            final int scaledWidth = (int) (available.getWidth() * globalScaleX);
-            final int scaledHeight = (int) (available.getHeight() * globalScaleY);
+            final Dimension bufferSize = new Dimension(
+                    (int) Math.ceil(availableWidth * globalScaleX),
+                    (int) Math.ceil(availableHeight * globalScaleY));
 
-            // do we need to resize the buffer?
-            if ((this.chartBuffer == null)
-                    || (this.chartBufferWidth != scaledWidth)
-                    || (this.chartBufferHeight != scaledHeight)) {
-                this.chartBufferWidth = scaledWidth;
-                this.chartBufferHeight = scaledHeight;
-                GraphicsConfiguration gc = g2.getDeviceConfiguration();
-                
-                this.chartBuffer = gc.createCompatibleImage(
-                        this.chartBufferWidth, this.chartBufferHeight,
-                        Transparency.TRANSLUCENT);
-                this.refreshBuffer = true;
-            }
-
-            // do we need to redraw the buffer?
-            if (this.refreshBuffer) {
-
-                this.refreshBuffer = false; // clear the flag
-
-                // scale graphics of the buffer to the same value as global 
-                // Swing graphics - this allow to paint all elements as usual 
-                // but applies all necessary smoothing
-                Graphics2D bufferG2 = (Graphics2D) this.chartBuffer.getGraphics();
-                bufferG2.scale(globalScaleX, globalScaleY);
-
-                Rectangle2D bufferArea = new Rectangle2D.Double(
-                        0, 0, available.getWidth(), available.getHeight());
-
-                // make the background of the buffer clear and transparent
-                Composite savedComposite = bufferG2.getComposite();
-                bufferG2.setComposite(AlphaComposite.getInstance(AlphaComposite.CLEAR, 0.0f));
-                Rectangle r = new Rectangle(0, 0, (int) available.getWidth(), (int) available.getHeight());
-                bufferG2.fill(r);
-                bufferG2.setComposite(savedComposite);
-                
-                if (scale) {
-                    AffineTransform saved = bufferG2.getTransform();
-                    AffineTransform st = AffineTransform.getScaleInstance(
-                            this.scaleX, this.scaleY);
-                    bufferG2.transform(st);
-                    this.chart.draw(bufferG2, chartArea, this.anchor,
-                            this.info);
-                    bufferG2.setTransform(saved);
-                } else {
-                    this.chart.draw(bufferG2, bufferArea, this.anchor,
-                            this.info);
-                }
-                bufferG2.dispose();
-            }
+            this.chartBuffer = paintChartToBuffer(g2, bufferSize, chartSize, anchor, info);
 
             // zap the buffer onto the panel...
-            g2.drawImage(this.chartBuffer, insets.left, insets.top, (int) available.getWidth(), (int) available.getHeight(), this);
+            g2.drawImage(this.chartBuffer, insets.left, insets.top, availableWidth, availableHeight, this);
             g2.addRenderingHints(this.chart.getRenderingHints()); // bug#187
 
         } else { // redrawing the chart every time...
@@ -1467,7 +1413,7 @@ public class ChartPanel extends JPanel implements ChartChangeListener,
                         this.scaleX, this.scaleY);
                 g2.transform(st);
             }
-            this.chart.draw(g2, chartArea, this.anchor, this.info);
+            this.chart.draw(g2, new Rectangle(chartSize), this.anchor, this.info);
             g2.setTransform(saved);
 
         }
@@ -1486,6 +1432,64 @@ public class ChartPanel extends JPanel implements ChartChangeListener,
         this.anchor = null;
         this.verticalTraceLine = null;
         this.horizontalTraceLine = null;
+    }
+
+    /**
+     * Paints the chart to fill the entire off-screen buffer image.
+     * 
+     * @param g2         the graphics context to create an off-screen buffer
+     *                   image.
+     * @param bufferSize the required off-screen buffer image size.
+     * @param chartSize  the size with which the chart should be drawn (apply
+     *                   scaling if not equal to {@code bufferSize}).
+     * @param anchor     the anchor point (in Java2D space) for the chart
+     *                   ({@code null} permitted).
+     * @param info       records info about the drawing ({@code null} means
+     *                   collect no info).
+     * @return the off-screen buffer image to draw onto the panel.
+     */
+    protected BufferedImage paintChartToBuffer(Graphics2D g2, Dimension bufferSize,
+            Dimension chartSize, Point2D anchor, ChartRenderingInfo info) {
+        final BufferedImage buffer;
+        if ((this.chartBuffer == null)
+                || (this.chartBuffer.getWidth() != bufferSize.width)
+                || (this.chartBuffer.getHeight() != bufferSize.height)) {
+            GraphicsConfiguration gc = g2.getDeviceConfiguration();
+
+            buffer = gc.createCompatibleImage(bufferSize.width,
+                    bufferSize.height, Transparency.TRANSLUCENT);
+
+            this.refreshBuffer = true;
+        } else {
+            buffer = this.chartBuffer;
+        }
+        
+        
+        // do we need to redraw the buffer?
+        if (this.refreshBuffer) {
+
+            this.refreshBuffer = false; // clear the flag
+
+            Graphics2D bufferG2 = buffer.createGraphics();
+            if (!bufferSize.equals(chartSize)) {
+                // Scale the chart to fit the buffer
+                bufferG2.scale(
+                        bufferSize.getWidth() / chartSize.getWidth(),
+                        bufferSize.getHeight() / chartSize.getHeight());
+            }
+            Rectangle chartArea = new Rectangle(chartSize);
+
+            // make the background of the buffer clear and transparent
+            Composite savedComposite = bufferG2.getComposite();
+            bufferG2.setComposite(AlphaComposite.getInstance(AlphaComposite.CLEAR, 0.0f));
+            bufferG2.fill(chartArea);
+            bufferG2.setComposite(savedComposite);
+            
+            this.chart.draw(bufferG2, chartArea, this.anchor, this.info);
+            bufferG2.dispose();
+        }
+        
+        return buffer;
     }
 
     /**

--- a/src/main/java/org/jfree/chart/ChartPanel.java
+++ b/src/main/java/org/jfree/chart/ChartPanel.java
@@ -1928,7 +1928,6 @@ public class ChartPanel extends JPanel implements ChartChangeListener,
         if (this.chart == null) {
             return;
         }
-        this.chart.setNotify(true);  // force a redraw
         // new entity code...
         Object[] listeners = this.chartMouseListeners.getListeners(
                 ChartMouseListener.class);

--- a/src/main/java/org/jfree/chart/ChartRenderingInfo.java
+++ b/src/main/java/org/jfree/chart/ChartRenderingInfo.java
@@ -203,7 +203,7 @@ public class ChartRenderingInfo implements Cloneable, Serializable {
      * @throws CloneNotSupportedException if the object cannot be cloned.
      */
     @Override
-    public Object clone() throws CloneNotSupportedException {
+    public ChartRenderingInfo clone() throws CloneNotSupportedException {
         ChartRenderingInfo clone = (ChartRenderingInfo) super.clone();
         if (this.chartArea != null) {
             clone.chartArea = (Rectangle2D) this.chartArea.clone();

--- a/src/main/java/org/jfree/chart/OfflineRenderingChartPanel.java
+++ b/src/main/java/org/jfree/chart/OfflineRenderingChartPanel.java
@@ -1,0 +1,427 @@
+/* ===========================================================
+ * JFreeChart : a free chart library for the Java(tm) platform
+ * ===========================================================
+ *
+ * (C) Copyright 2000-2021, by Object Refinery Limited and Contributors.
+ *
+ * Project Info:  http://www.jfree.org/jfreechart/index.html
+ *
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ * [Oracle and Java are registered trademarks of Oracle and/or its affiliates. 
+ * Other names may be trademarks of their respective owners.]
+ *
+ * ---------------
+ * ChartPanel.java
+ * ---------------
+ * (C) Copyright 2000-2021, by Object Refinery Limited and Contributors.
+ *
+ * Original Author:  Yuri Blankenstein;
+ */
+package org.jfree.chart;
+
+import java.awt.AlphaComposite;
+import java.awt.Container;
+import java.awt.Cursor;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.awt.GraphicsConfiguration;
+import java.awt.Rectangle;
+import java.awt.Transparency;
+import java.awt.geom.Point2D;
+import java.awt.image.BufferedImage;
+
+import javax.swing.SwingWorker;
+
+import org.jfree.chart.entity.EntityCollection;
+import org.jfree.chart.plot.PlotRenderingInfo;
+
+/**
+ * A {@link ChartPanel} that applies offline rendering, for better performance
+ * when navigating (i.e. panning / zooming) {@link JFreeChart charts} with lots
+ * of data.
+ * <P>
+ * This chart panel uses a {@link SwingWorker} to perform the actual
+ * {@link JFreeChart} rendering. While rendering, a {@link Cursor#WAIT_CURSOR
+ * wait cursor} is visible and the current buffered image of the chart will be
+ * scaled and drawn to the screen. When - while rendering - another
+ * {@link #setRefreshBuffer(boolean) refresh} is requested, this will be either
+ * postponed until the current rendering is done or ignored when another refresh
+ * is requested.
+ */
+public class OfflineRenderingChartPanel extends ChartPanel {
+    private static final long serialVersionUID = -724633596883320084L;
+
+    /**
+     * Using enum state pattern to control the 'offline' rendering
+     */
+    protected enum State {
+        IDLE {
+            @Override
+            protected State renderOffline(OfflineRenderingChartPanel panel,
+                    OfflineChartRenderer renderer) {
+                // Start rendering offline
+                renderer.execute();
+                panel.setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
+                return RENDERING;
+            }
+
+            @Override
+            protected State offlineRenderingDone(
+                    OfflineRenderingChartPanel panel,
+                    OfflineChartRenderer renderer) {
+                throw new IllegalStateException(
+                        "offlineRenderingDone not expected in IDLE state");
+            }
+        },
+        RENDERING {
+            @Override
+            protected State renderOffline(OfflineRenderingChartPanel panel,
+                    OfflineChartRenderer renderer) {
+                // We're already rendering, we'll start this renderer when we're
+                // finished. If another rendering is requested, this one will be
+                // ignored, see RE_RENDERING_PENDING. This gains a lot of speed
+                // as not all requested (intermediate) renderings are executed
+                // for large plots.
+                panel.pendingOfflineRenderer = renderer;
+                return RE_RENDERING_PENDING;
+            }
+
+            @Override
+            protected State offlineRenderingDone(
+                    OfflineRenderingChartPanel panel,
+                    OfflineChartRenderer renderer) {
+                // Offline rendering done, prepare the buffer and info for the
+                // next repaint and request it.
+                panel.currentChartBuffer = renderer.buffer;
+                panel.currentChartRenderingInfo = renderer.info;
+                panel.repaint();
+                panel.setCursor(Cursor.getPredefinedCursor(Cursor.DEFAULT_CURSOR));
+                return IDLE;
+            }
+        },
+        RE_RENDERING_PENDING {
+            @Override
+            protected State renderOffline(OfflineRenderingChartPanel panel,
+                    OfflineChartRenderer renderer) {
+                // We're already rendering, we'll start this renderer when we're
+                // finished.
+                panel.pendingOfflineRenderer = renderer;
+                return RE_RENDERING_PENDING;
+            }
+
+            @Override
+            protected State offlineRenderingDone(
+                    OfflineRenderingChartPanel panel,
+                    OfflineChartRenderer renderer) {
+                // Store the intermediate result, but do not actively repaint
+                // as this could trigger another RE_RENDERING_PENDING if i.e.
+                // the buffer-image-size of the pending renderer differs from
+                // the current buffer-image-size.
+                panel.currentChartBuffer = renderer.buffer;
+                panel.currentChartRenderingInfo = renderer.info;
+                // Immediately start rendering again to update the chart to the
+                // latest requested state.
+                panel.pendingOfflineRenderer.execute();
+                panel.pendingOfflineRenderer = null;
+                return RENDERING;
+            }
+        };
+
+        protected abstract State renderOffline(
+                final OfflineRenderingChartPanel panel,
+                final OfflineChartRenderer renderer);
+
+        protected abstract State offlineRenderingDone(
+                final OfflineRenderingChartPanel panel,
+                final OfflineChartRenderer renderer);
+    }
+
+    /** A buffer for the rendered chart. */
+    private transient BufferedImage currentChartBuffer = null;
+    private transient ChartRenderingInfo currentChartRenderingInfo = null;
+
+    /** A pending rendering for the chart. */
+    private transient OfflineChartRenderer pendingOfflineRenderer = null;
+
+    private State state = State.IDLE;
+
+    /**
+     * Constructs a double buffered JFreeChart panel that displays the specified
+     * chart.
+     *
+     * @param chart the chart.
+     */
+    public OfflineRenderingChartPanel(JFreeChart chart) {
+        this(chart, DEFAULT_WIDTH, DEFAULT_HEIGHT, DEFAULT_MINIMUM_DRAW_WIDTH,
+                DEFAULT_MINIMUM_DRAW_HEIGHT, DEFAULT_MAXIMUM_DRAW_WIDTH,
+                DEFAULT_MAXIMUM_DRAW_HEIGHT, true, // properties
+                true, // save
+                true, // print
+                true, // zoom
+                true // tooltips
+        );
+
+    }
+
+    /**
+     * Constructs a double buffered JFreeChart panel.
+     *
+     * @param chart      the chart.
+     * @param properties a flag indicating whether or not the chart property
+     *                   editor should be available via the popup menu.
+     * @param save       a flag indicating whether or not save options should be
+     *                   available via the popup menu.
+     * @param print      a flag indicating whether or not the print option
+     *                   should be available via the popup menu.
+     * @param zoom       a flag indicating whether or not zoom options should be
+     *                   added to the popup menu.
+     * @param tooltips   a flag indicating whether or not tooltips should be
+     *                   enabled for the chart.
+     */
+    public OfflineRenderingChartPanel(JFreeChart chart, boolean properties,
+            boolean save, boolean print, boolean zoom, boolean tooltips) {
+
+        this(chart, DEFAULT_WIDTH, DEFAULT_HEIGHT, DEFAULT_MINIMUM_DRAW_WIDTH,
+                DEFAULT_MINIMUM_DRAW_HEIGHT, DEFAULT_MAXIMUM_DRAW_WIDTH,
+                DEFAULT_MAXIMUM_DRAW_HEIGHT, properties, save, print, zoom,
+                tooltips);
+
+    }
+
+    /**
+     * Constructs a double buffered JFreeChart panel.
+     *
+     * @param chart             the chart.
+     * @param width             the preferred width of the panel.
+     * @param height            the preferred height of the panel.
+     * @param minimumDrawWidth  the minimum drawing width.
+     * @param minimumDrawHeight the minimum drawing height.
+     * @param maximumDrawWidth  the maximum drawing width.
+     * @param maximumDrawHeight the maximum drawing height.
+     * @param properties        a flag indicating whether or not the chart
+     *                          property editor should be available via the
+     *                          popup menu.
+     * @param save              a flag indicating whether or not save options
+     *                          should be available via the popup menu.
+     * @param print             a flag indicating whether or not the print
+     *                          option should be available via the popup menu.
+     * @param zoom              a flag indicating whether or not zoom options
+     *                          should be added to the popup menu.
+     * @param tooltips          a flag indicating whether or not tooltips should
+     *                          be enabled for the chart.
+     */
+    public OfflineRenderingChartPanel(JFreeChart chart, int width, int height,
+            int minimumDrawWidth, int minimumDrawHeight, int maximumDrawWidth,
+            int maximumDrawHeight, boolean properties, boolean save,
+            boolean print, boolean zoom, boolean tooltips) {
+
+        this(chart, width, height, minimumDrawWidth, minimumDrawHeight,
+                maximumDrawWidth, maximumDrawHeight, properties, true, save,
+                print, zoom, tooltips);
+    }
+
+    /**
+     * Constructs a double buffered JFreeChart panel.
+     *
+     * @param chart             the chart.
+     * @param width             the preferred width of the panel.
+     * @param height            the preferred height of the panel.
+     * @param minimumDrawWidth  the minimum drawing width.
+     * @param minimumDrawHeight the minimum drawing height.
+     * @param maximumDrawWidth  the maximum drawing width.
+     * @param maximumDrawHeight the maximum drawing height.
+     * @param properties        a flag indicating whether or not the chart
+     *                          property editor should be available via the
+     *                          popup menu.
+     * @param copy              a flag indicating whether or not a copy option
+     *                          should be available via the popup menu.
+     * @param save              a flag indicating whether or not save options
+     *                          should be available via the popup menu.
+     * @param print             a flag indicating whether or not the print
+     *                          option should be available via the popup menu.
+     * @param zoom              a flag indicating whether or not zoom options
+     *                          should be added to the popup menu.
+     * @param tooltips          a flag indicating whether or not tooltips should
+     *                          be enabled for the chart.
+     */
+    public OfflineRenderingChartPanel(JFreeChart chart, int width, int height,
+            int minimumDrawWidth, int minimumDrawHeight, int maximumDrawWidth,
+            int maximumDrawHeight, boolean properties, boolean copy,
+            boolean save, boolean print, boolean zoom, boolean tooltips) {
+        super(chart, width, height, minimumDrawWidth, minimumDrawHeight,
+                maximumDrawWidth, maximumDrawHeight, true, properties, copy,
+                save, print, zoom, tooltips);
+    }
+
+    @Override
+    protected BufferedImage paintChartToBuffer(Graphics2D g2,
+            Dimension bufferSize, Dimension chartSize, Point2D anchor,
+            ChartRenderingInfo info) {
+        synchronized (state) {
+            if (this.currentChartBuffer == null) {
+                // Rendering the first time, prepare an empty buffer and
+                // start rendering, no need for an additional state
+                this.currentChartBuffer = createChartBuffer(g2, bufferSize);
+                clearChartBuffer(currentChartBuffer);
+                setRefreshBuffer(true);
+            } else if ((this.currentChartBuffer.getWidth() != bufferSize.width)
+                    || (this.currentChartBuffer
+                            .getHeight() != bufferSize.height)) {
+                setRefreshBuffer(true);
+            }
+
+            // do we need to redraw the buffer?
+            if (getRefreshBuffer()) {
+                setRefreshBuffer(false); // clear the flag
+
+                // Rendering is done offline, hence it requires a fresh buffer
+                // and rendering info
+                BufferedImage rendererBuffer = createChartBuffer(g2,
+                        bufferSize);
+                ChartRenderingInfo rendererInfo = info;
+                if (rendererInfo != null) {
+                    // As the chart will be re-rendered, the current chart
+                    // entities cannot be trusted
+                    final EntityCollection entityCollection = 
+                            rendererInfo.getEntityCollection();
+                    if (entityCollection != null) {
+                        entityCollection.clear();
+                    }
+
+                    // Offline rendering requires its own instance of
+                    // ChartRenderingInfo, using clone if possible
+                    try {
+                        rendererInfo = rendererInfo.clone();
+                    } catch (CloneNotSupportedException e) {
+                        // Not expected
+                        e.printStackTrace();
+                        rendererInfo = new ChartRenderingInfo();
+                    }
+                }
+
+                OfflineChartRenderer offlineRenderer = new OfflineChartRenderer(
+                        getChart(), rendererBuffer, chartSize, anchor,
+                        rendererInfo);
+                state = state.renderOffline(this, offlineRenderer);
+            }
+
+            // Copy the rendered ChartRenderingInfo into the passed info
+            // argument and mark that we have done so.
+            copyChartRenderingInfo(this.currentChartRenderingInfo, info);
+            this.currentChartRenderingInfo = info;
+
+            return this.currentChartBuffer;
+        }
+    }
+
+    private class OfflineChartRenderer extends SwingWorker<Object, Object> {
+        private final JFreeChart chart;
+        private final BufferedImage buffer;
+        private final Dimension chartSize;
+        private final Point2D anchor;
+        private final ChartRenderingInfo info;
+
+        public OfflineChartRenderer(JFreeChart chart, BufferedImage image,
+                Dimension chartSize, Point2D anchor, ChartRenderingInfo info) {
+            this.chart = chart;
+            this.buffer = image;
+            this.chartSize = chartSize;
+            this.anchor = anchor;
+            this.info = info;
+        }
+
+        @Override
+        protected Object doInBackground() throws Exception {
+            clearChartBuffer(buffer);
+
+            Graphics2D bufferG2 = buffer.createGraphics();
+            if ((this.buffer.getWidth() != this.chartSize.width)
+                    || (this.buffer.getHeight() != this.chartSize.height)) {
+                // Scale the chart to fit the buffer
+                bufferG2.scale(
+                        this.buffer.getWidth() / this.chartSize.getWidth(),
+                        this.buffer.getHeight() / this.chartSize.getHeight());
+            }
+            Rectangle chartArea = new Rectangle(this.chartSize);
+
+            this.chart.draw(bufferG2, chartArea, this.anchor, this.info);
+            bufferG2.dispose();
+
+            // Return type is not used
+            return null;
+        }
+
+        @Override
+        protected void done() {
+            synchronized (state) {
+                state = state.offlineRenderingDone(
+                        OfflineRenderingChartPanel.this, this);
+            }
+        }
+    }
+
+    @Override
+    public void setCursor(Cursor cursor) {
+        super.setCursor(cursor);
+
+        // Buggy mouse cursor: setting both behaves as expected
+        Container root = getTopLevelAncestor();
+        if (null != root) {
+            root.setCursor(cursor);
+        }
+    }
+
+    private static void copyChartRenderingInfo(ChartRenderingInfo source,
+            ChartRenderingInfo target) {
+        if (source == null || target == null || source == target) {
+            // Nothing to do
+            return;
+        }
+        target.clear();
+        target.setChartArea(source.getChartArea());
+        target.setEntityCollection(source.getEntityCollection());
+        copyPlotRenderingInfo(source.getPlotInfo(), target.getPlotInfo());
+    }
+
+    private static void copyPlotRenderingInfo(PlotRenderingInfo source,
+            PlotRenderingInfo target) {
+        target.setDataArea(source.getDataArea());
+        target.setPlotArea(source.getPlotArea());
+        for (int i = 0; i < target.getSubplotCount(); i++) {
+            PlotRenderingInfo subSource = source.getSubplotInfo(i);
+            PlotRenderingInfo subTarget = new PlotRenderingInfo(
+                    target.getOwner());
+            copyPlotRenderingInfo(subSource, subTarget);
+            target.addSubplotInfo(subTarget);
+        }
+    }
+
+    private static BufferedImage createChartBuffer(Graphics2D g2,
+            Dimension bufferSize) {
+        GraphicsConfiguration gc = g2.getDeviceConfiguration();
+        return gc.createCompatibleImage(bufferSize.width, bufferSize.height,
+                Transparency.TRANSLUCENT);
+    }
+
+    private static void clearChartBuffer(BufferedImage buffer) {
+        Graphics2D bufferG2 = buffer.createGraphics();
+        // make the background of the buffer clear and transparent
+        bufferG2.setComposite(AlphaComposite.getInstance(AlphaComposite.CLEAR, 0.0f));
+        bufferG2.fill(new Rectangle(buffer.getWidth(), buffer.getHeight()));
+        bufferG2.dispose();
+    }
+}


### PR DESCRIPTION
This merge request contains a patch to improve the performance of JFreeChart when using large datasets (i.e. datasets that require much time to be rendered). The proposed solution is described in the JavaDoc of OfflineRenderingChartPanel.java