### PR TITLE
Fixed "unneeded cast" warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,12 @@
             <version>5.8.1</version>
             <scope>test</scope>
         </dependency>
+		<dependency>
+		    <groupId>nl.jqno.equalsverifier</groupId>
+		    <artifactId>equalsverifier</artifactId>
+		    <version>3.7.2</version>
+		    <scope>test</scope>
+		</dependency>
     </dependencies>
 
     <distributionManagement>

--- a/src/test/java/org/jfree/chart/ChartRenderingInfoTest.java
+++ b/src/test/java/org/jfree/chart/ChartRenderingInfoTest.java
@@ -116,7 +116,7 @@ public class ChartRenderingInfoTest  {
     public void testSerialization() {
         ChartRenderingInfo i1 = new ChartRenderingInfo();
         i1.setChartArea(new Rectangle2D.Double(1.0, 2.0, 3.0, 4.0));
-        ChartRenderingInfo i2 = (ChartRenderingInfo) TestUtils.serialised(i1);
+        ChartRenderingInfo i2 = TestUtils.serialised(i1);
         assertEquals(i1, i2);
     }
 
@@ -128,7 +128,7 @@ public class ChartRenderingInfoTest  {
         ChartRenderingInfo i1 = new ChartRenderingInfo();
         i1.getPlotInfo().setDataArea(new Rectangle2D.Double(1.0, 2.0, 3.0,
                 4.0));
-        ChartRenderingInfo i2 = (ChartRenderingInfo) TestUtils.serialised(i1);
+        ChartRenderingInfo i2 = TestUtils.serialised(i1);
         assertEquals(i1, i2);
         assertEquals(i2, i2.getPlotInfo().getOwner());
     }

--- a/src/test/java/org/jfree/chart/FakePlot.java
+++ b/src/test/java/org/jfree/chart/FakePlot.java
@@ -1,0 +1,25 @@
+package org.jfree.chart;
+
+import java.awt.Graphics2D;
+import java.awt.geom.Point2D;
+import java.awt.geom.Rectangle2D;
+import org.jfree.chart.plot.Plot;
+import org.jfree.chart.plot.PlotRenderingInfo;
+import org.jfree.chart.plot.PlotState;
+
+/**
+ * Dummy extension of Plot for JUnit testing using the EqualsVerifier library
+ */
+public class FakePlot extends Plot {
+
+    @Override
+    public String getPlotType() {
+        return "Fake";
+    }
+
+    @Override
+    public void draw(Graphics2D g2, Rectangle2D area, Point2D anchor,
+                     PlotState parentState, PlotRenderingInfo info) {
+        ;
+    }
+}

--- a/src/test/java/org/jfree/chart/FakeValueAxis.java
+++ b/src/test/java/org/jfree/chart/FakeValueAxis.java
@@ -1,0 +1,52 @@
+package org.jfree.chart;
+
+import java.awt.Graphics2D;
+import java.awt.geom.Rectangle2D;
+import java.util.ArrayList;
+import java.util.List;
+import org.jfree.chart.axis.AxisState;
+import org.jfree.chart.axis.TickUnitSource;
+import org.jfree.chart.axis.ValueAxis;
+import org.jfree.chart.plot.PlotRenderingInfo;
+import org.jfree.chart.ui.RectangleEdge;
+
+/**
+ * Dummy extension of ValueAxis for JUnit testing using the EqualsVerifier
+ * library.
+ */
+public class FakeValueAxis extends ValueAxis {
+
+    public FakeValueAxis(String label, TickUnitSource standardTickUnits) {
+        super(label, standardTickUnits);
+    }
+
+    @Override
+    public double valueToJava2D(double value, Rectangle2D area, RectangleEdge edge) {
+        return 0;
+    }
+
+    @Override
+    public double java2DToValue(double java2DValue, Rectangle2D area, RectangleEdge edge) {
+        return 0;
+    }
+
+    @Override
+    protected void autoAdjustRange() {
+        ;
+    }
+
+    @Override
+    public void configure() {
+        ;
+    }
+
+    @Override
+    public AxisState draw(Graphics2D g2, double cursor, Rectangle2D plotArea, Rectangle2D dataArea, RectangleEdge edge, PlotRenderingInfo plotState) {
+        return new AxisState();
+    }
+
+    @Override
+    public List refreshTicks(Graphics2D g2, AxisState state, Rectangle2D dataArea, RectangleEdge edge) {
+        return new ArrayList<>();
+    }
+}

--- a/src/test/java/org/jfree/chart/JFreeChartTest.java
+++ b/src/test/java/org/jfree/chart/JFreeChartTest.java
@@ -330,7 +330,7 @@ public class JFreeChartTest implements ChartChangeListener {
         // create the chart...
         JFreeChart c1 = ChartFactory.createBarChart("Vertical Bar Chart",
                 "Category", "Value", dataset);
-        JFreeChart c2 = (JFreeChart) TestUtils.serialised(c1);
+        JFreeChart c2 = TestUtils.serialised(c1);
         assertEquals(c1, c2);
     }
 
@@ -350,7 +350,7 @@ public class JFreeChartTest implements ChartChangeListener {
 
         JFreeChart c1 = ChartFactory.createTimeSeriesChart("Test", "Date",
                 "Value", dataset);
-        JFreeChart c2 = (JFreeChart) TestUtils.serialised(c1);
+        JFreeChart c2 = TestUtils.serialised(c1);
         assertEquals(c1, c2);
     }
 

--- a/src/test/java/org/jfree/chart/LegendItemCollectionTest.java
+++ b/src/test/java/org/jfree/chart/LegendItemCollectionTest.java
@@ -90,7 +90,7 @@ public class LegendItemCollectionTest  {
         LegendItemCollection c1 = new LegendItemCollection();
         c1.add(new LegendItem("Item", "Description", "ToolTip", "URL",
                 new Rectangle2D.Double(1.0, 2.0, 3.0, 4.0), Color.RED));
-        LegendItemCollection c2 = (LegendItemCollection) TestUtils.serialised(c1);
+        LegendItemCollection c2 = TestUtils.serialised(c1);
         assertEquals(c1, c2);
     }
 

--- a/src/test/java/org/jfree/chart/LegendItemTest.java
+++ b/src/test/java/org/jfree/chart/LegendItemTest.java
@@ -313,7 +313,7 @@ public class LegendItemTest {
         item1.setLinePaint(new GradientPaint(1.0f, 2.0f, Color.WHITE, 3.0f,
                 4.0f, Color.RED));
         LegendItem item2;
-        item2 = (LegendItem) TestUtils.serialised(item1);
+        item2 = TestUtils.serialised(item1);
         assertEquals(item1, item2);
     }
 
@@ -326,7 +326,7 @@ public class LegendItemTest {
         as.addAttribute(TextAttribute.FONT, new Font("Dialog", Font.PLAIN, 12));
         LegendItem item1 = new LegendItem(as, "Description", "ToolTip", "URL",
                 new Rectangle2D.Double(1.0, 2.0, 3.0, 4.0), Color.RED);
-        LegendItem item2 = (LegendItem) TestUtils.serialised(item1);
+        LegendItem item2 = TestUtils.serialised(item1);
         assertEquals(item1, item2);
     }
 

--- a/src/test/java/org/jfree/chart/PaintMapTest.java
+++ b/src/test/java/org/jfree/chart/PaintMapTest.java
@@ -146,7 +146,7 @@ public class PaintMapTest  {
     @Test
     public void testSerialization1() {
         PaintMap m1 = new PaintMap();
-        PaintMap m2 = (PaintMap) TestUtils.serialised(m1);
+        PaintMap m2 = TestUtils.serialised(m1);
         assertEquals(m1, m2);
     }
 
@@ -159,7 +159,7 @@ public class PaintMapTest  {
         m1.put("K1", Color.RED);
         m1.put("K2", new GradientPaint(1.0f, 2.0f, Color.GREEN, 3.0f, 4.0f,
                 Color.YELLOW));
-        PaintMap m2 = (PaintMap) TestUtils.serialised(m1);
+        PaintMap m2 = TestUtils.serialised(m1);
         assertEquals(m1, m2);
     }
 

--- a/src/test/java/org/jfree/chart/StandardChartThemeTest.java
+++ b/src/test/java/org/jfree/chart/StandardChartThemeTest.java
@@ -255,7 +255,7 @@ public class StandardChartThemeTest {
     @Test
     public void testSerialization() {
         StandardChartTheme t1 = new StandardChartTheme("Name");
-        StandardChartTheme t2 = (StandardChartTheme) TestUtils.serialised(t1);
+        StandardChartTheme t2 = TestUtils.serialised(t1);
         assertTrue(t1.equals(t2));
     }
 

--- a/src/test/java/org/jfree/chart/StrokeMapTest.java
+++ b/src/test/java/org/jfree/chart/StrokeMapTest.java
@@ -152,7 +152,7 @@ public class StrokeMapTest {
         StrokeMap m1 = new StrokeMap();
         m1.put("K1", new BasicStroke(1.1f));
         m1.put("K2", new BasicStroke(2.2f));
-        StrokeMap m2 = (StrokeMap) TestUtils.serialised(m1);
+        StrokeMap m2 = TestUtils.serialised(m1);
         assertEquals(m1, m2);
     }
 

--- a/src/test/java/org/jfree/chart/TestUtils.java
+++ b/src/test/java/org/jfree/chart/TestUtils.java
@@ -36,6 +36,8 @@
 
 package org.jfree.chart;
 
+import java.awt.Font;
+import java.awt.geom.Rectangle2D;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -45,11 +47,53 @@ import java.io.ObjectOutput;
 import java.io.ObjectOutputStream;
 import java.util.Collection;
 import java.util.Iterator;
+import org.jfree.chart.axis.ValueAxis;
+import org.jfree.chart.plot.MeterPlot;
+import org.jfree.chart.plot.Plot;
+import org.jfree.data.general.DefaultValueDataset;
 
 /**
  * Some utility methods for use by the testing code.
  */
 public class TestUtils {
+
+    public static Rectangle2D createR2D(boolean isRed) {
+        if (isRed) {
+            return new Rectangle2D.Double(0, 0, 1, 1);
+        } else {
+            return new Rectangle2D.Double(1, 1, 2, 2);
+        }
+    }
+
+    public static Font createFont(boolean isRed) {
+        if (isRed) {
+            return new Font("SansSerif", Font.PLAIN, 12);
+        } else {
+            return new Font("Dialog", Font.BOLD, 10);
+        }
+    }
+
+    public static JFreeChart createJFC(boolean isRed) {
+        if (isRed) {
+            return new JFreeChart("abc", new MeterPlot(new DefaultValueDataset(44)));
+        } else {
+            return new JFreeChart("xyz", new MeterPlot(new DefaultValueDataset(55)));
+        }
+    }
+
+    public static Plot createPlot(boolean isRed) {
+        FakePlot plot = new FakePlot();
+        plot.setNotify(isRed);
+        return plot;
+    }
+
+    public static ValueAxis createValueAxis(boolean isRed) {
+        if (isRed) {
+            return new FakeValueAxis("Fake1", null);
+        } else {
+            return new FakeValueAxis("Fake2", null);
+        }
+    }
 
     /**
      * Returns {@code true} if the collections contains any object that

--- a/src/test/java/org/jfree/chart/annotations/CategoryLineAnnotationTest.java
+++ b/src/test/java/org/jfree/chart/annotations/CategoryLineAnnotationTest.java
@@ -181,7 +181,7 @@ public class CategoryLineAnnotationTest {
     public void testSerialization() {
         CategoryLineAnnotation a1 = new CategoryLineAnnotation("Category 1", 
                 1.0, "Category 2", 2.0, Color.RED, new BasicStroke(1.0f));
-        CategoryLineAnnotation a2 = (CategoryLineAnnotation) TestUtils.serialised(a1);
+        CategoryLineAnnotation a2 = TestUtils.serialised(a1);
         assertEquals(a1, a2);
     }
 

--- a/src/test/java/org/jfree/chart/annotations/CategoryPointerAnnotationTest.java
+++ b/src/test/java/org/jfree/chart/annotations/CategoryPointerAnnotationTest.java
@@ -175,8 +175,7 @@ public class CategoryPointerAnnotationTest {
     public void testSerialization() {
         CategoryPointerAnnotation a1 = new CategoryPointerAnnotation("Label",
                 "A", 20.0, Math.PI);
-        CategoryPointerAnnotation a2 = (CategoryPointerAnnotation) 
-                TestUtils.serialised(a1);
+        CategoryPointerAnnotation a2 = TestUtils.serialised(a1);
         assertEquals(a1, a2);
     }
 

--- a/src/test/java/org/jfree/chart/annotations/CategoryTextAnnotationTest.java
+++ b/src/test/java/org/jfree/chart/annotations/CategoryTextAnnotationTest.java
@@ -126,7 +126,7 @@ public class CategoryTextAnnotationTest {
     public void testSerialization() {
         CategoryTextAnnotation a1 = new CategoryTextAnnotation("Test", 
                 "Category", 1.0);
-        CategoryTextAnnotation a2 = (CategoryTextAnnotation) TestUtils.serialised(a1);
+        CategoryTextAnnotation a2 = TestUtils.serialised(a1);
         assertEquals(a1, a2);
     }
 

--- a/src/test/java/org/jfree/chart/annotations/XYBoxAnnotationTest.java
+++ b/src/test/java/org/jfree/chart/annotations/XYBoxAnnotationTest.java
@@ -182,7 +182,7 @@ public class XYBoxAnnotationTest {
     public void testSerialization() {
         XYBoxAnnotation a1 = new XYBoxAnnotation(1.0, 2.0, 3.0, 4.0,
                 new BasicStroke(1.2f), Color.RED, Color.BLUE);
-        XYBoxAnnotation a2 = (XYBoxAnnotation) TestUtils.serialised(a1);
+        XYBoxAnnotation a2 = TestUtils.serialised(a1);
         assertEquals(a1, a2);
     }
 

--- a/src/test/java/org/jfree/chart/annotations/XYDrawableAnnotationTest.java
+++ b/src/test/java/org/jfree/chart/annotations/XYDrawableAnnotationTest.java
@@ -190,7 +190,7 @@ public class XYDrawableAnnotationTest {
     public void testSerialization() {
         XYDrawableAnnotation a1 = new XYDrawableAnnotation(10.0, 20.0, 100.0,
                 200.0, new TestDrawable());
-        XYDrawableAnnotation a2 = (XYDrawableAnnotation) TestUtils.serialised(a1);
+        XYDrawableAnnotation a2 = TestUtils.serialised(a1);
         assertEquals(a1, a2);
     }
 

--- a/src/test/java/org/jfree/chart/annotations/XYLineAnnotationTest.java
+++ b/src/test/java/org/jfree/chart/annotations/XYLineAnnotationTest.java
@@ -198,7 +198,7 @@ public class XYLineAnnotationTest {
         Stroke stroke = new BasicStroke(2.0f);
         XYLineAnnotation a1 = new XYLineAnnotation(10.0, 20.0, 100.0, 200.0,
                 stroke, Color.BLUE);
-        XYLineAnnotation a2 = (XYLineAnnotation) TestUtils.serialised(a1);
+        XYLineAnnotation a2 = TestUtils.serialised(a1);
         assertEquals(a1, a2);
     }
 

--- a/src/test/java/org/jfree/chart/annotations/XYPointerAnnotationTest.java
+++ b/src/test/java/org/jfree/chart/annotations/XYPointerAnnotationTest.java
@@ -152,7 +152,7 @@ public class XYPointerAnnotationTest {
     public void testCloning() throws CloneNotSupportedException {
         XYPointerAnnotation a1 = new XYPointerAnnotation("Label", 10.0, 20.0,
                 Math.PI);
-        XYPointerAnnotation a2 = a2 = (XYPointerAnnotation) a1.clone();
+        XYPointerAnnotation a2 = (XYPointerAnnotation) a1.clone();
         assertTrue(a1 != a2);
         assertTrue(a1.getClass() == a2.getClass());
         assertTrue(a1.equals(a2));
@@ -175,7 +175,7 @@ public class XYPointerAnnotationTest {
     public void testSerialization() {
         XYPointerAnnotation a1 = new XYPointerAnnotation("Label", 10.0, 20.0,
                 Math.PI);
-        XYPointerAnnotation a2 = (XYPointerAnnotation) TestUtils.serialised(a1);
+        XYPointerAnnotation a2 = TestUtils.serialised(a1);
         assertEquals(a1, a2);
     }
 

--- a/src/test/java/org/jfree/chart/annotations/XYPolygonAnnotationTest.java
+++ b/src/test/java/org/jfree/chart/annotations/XYPolygonAnnotationTest.java
@@ -154,7 +154,7 @@ public class XYPolygonAnnotationTest {
         Stroke stroke1 = new BasicStroke(2.0f);
         XYPolygonAnnotation a1 = new XYPolygonAnnotation(new double[] {1.0,
                 2.0, 3.0, 4.0, 5.0, 6.0}, stroke1, Color.RED, Color.BLUE);
-        XYPolygonAnnotation a2 = (XYPolygonAnnotation) TestUtils.serialised(a1);
+        XYPolygonAnnotation a2 = TestUtils.serialised(a1);
         assertEquals(a1, a2);
     }
 

--- a/src/test/java/org/jfree/chart/annotations/XYShapeAnnotationTest.java
+++ b/src/test/java/org/jfree/chart/annotations/XYShapeAnnotationTest.java
@@ -170,7 +170,7 @@ public class XYShapeAnnotationTest {
         XYShapeAnnotation a1 = new XYShapeAnnotation(
                 new Rectangle2D.Double(1.0, 2.0, 3.0, 4.0),
                 new BasicStroke(1.2f), Color.RED, Color.BLUE);
-        XYShapeAnnotation a2 = (XYShapeAnnotation) TestUtils.serialised(a1);
+        XYShapeAnnotation a2 = TestUtils.serialised(a1);
         assertEquals(a1, a2);
     }
 

--- a/src/test/java/org/jfree/chart/annotations/XYTextAnnotationTest.java
+++ b/src/test/java/org/jfree/chart/annotations/XYTextAnnotationTest.java
@@ -181,7 +181,7 @@ public class XYTextAnnotationTest {
         XYTextAnnotation a1 = new XYTextAnnotation("Text", 10.0, 20.0);
         a1.setOutlinePaint(new GradientPaint(1.0f, 2.0f, Color.RED, 3.0f, 4.0f,
                 Color.BLUE));
-        XYTextAnnotation a2 = (XYTextAnnotation) TestUtils.serialised(a1);
+        XYTextAnnotation a2 = TestUtils.serialised(a1);
         assertEquals(a1, a2);
     }
 

--- a/src/test/java/org/jfree/chart/annotations/XYTitleAnnotationTest.java
+++ b/src/test/java/org/jfree/chart/annotations/XYTitleAnnotationTest.java
@@ -117,7 +117,7 @@ public class XYTitleAnnotationTest {
     public void testSerialization() {
         TextTitle t = new TextTitle("Title");
         XYTitleAnnotation a1 = new XYTitleAnnotation(1.0, 2.0, t);
-        XYTitleAnnotation a2 = (XYTitleAnnotation) TestUtils.serialised(a1);
+        XYTitleAnnotation a2 = TestUtils.serialised(a1);
         assertEquals(a1, a2);
     }
     

--- a/src/test/java/org/jfree/chart/axis/AxisLocationTest.java
+++ b/src/test/java/org/jfree/chart/axis/AxisLocationTest.java
@@ -78,7 +78,7 @@ public class AxisLocationTest {
     @Test
     public void testSerialization() {
         AxisLocation location1 = AxisLocation.BOTTOM_OR_RIGHT;
-        AxisLocation location2 = (AxisLocation) TestUtils.serialised(location1);
+        AxisLocation location2 = TestUtils.serialised(location1);
         assertEquals(location1, location2);
         boolean same = location1 == location2;
         assertEquals(true, same);

--- a/src/test/java/org/jfree/chart/axis/AxisTest.java
+++ b/src/test/java/org/jfree/chart/axis/AxisTest.java
@@ -264,7 +264,7 @@ public class AxisTest  {
         label.addAttribute(TextAttribute.SUPERSCRIPT, 
                 TextAttribute.SUPERSCRIPT_SUB, 1, 4);
         a1.setAttributedLabel(label);
-        Axis a2 = (Axis) TestUtils.serialised(a1);
+        Axis a2 = TestUtils.serialised(a1);
         assertEquals(a1, a2);
     }
 

--- a/src/test/java/org/jfree/chart/axis/CategoryAnchorTest.java
+++ b/src/test/java/org/jfree/chart/axis/CategoryAnchorTest.java
@@ -79,7 +79,7 @@ public class CategoryAnchorTest {
     @Test
     public void testSerialization() {
         CategoryAnchor a1 = CategoryAnchor.MIDDLE;
-        CategoryAnchor a2 = (CategoryAnchor) TestUtils.serialised(a1);
+        CategoryAnchor a2 = TestUtils.serialised(a1);
         assertEquals(a1, a2);
         assertTrue(a1 == a2);
     }

--- a/src/test/java/org/jfree/chart/axis/CategoryAxisTest.java
+++ b/src/test/java/org/jfree/chart/axis/CategoryAxisTest.java
@@ -198,7 +198,7 @@ public class CategoryAxisTest {
         CategoryAxis a1 = new CategoryAxis("Test Axis");
         a1.setTickLabelPaint("C1", new GradientPaint(1.0f, 2.0f, Color.RED,
                 3.0f, 4.0f, Color.WHITE));
-        CategoryAxis a2 = (CategoryAxis) TestUtils.serialised(a1);
+        CategoryAxis a2 = TestUtils.serialised(a1);
         assertEquals(a1, a2);
     }
 

--- a/src/test/java/org/jfree/chart/axis/CategoryLabelPositionTest.java
+++ b/src/test/java/org/jfree/chart/axis/CategoryLabelPositionTest.java
@@ -142,7 +142,7 @@ public class CategoryLabelPositionTest {
     @Test
     public void testSerialization() {
         CategoryLabelPosition p1 = new CategoryLabelPosition();
-        CategoryLabelPosition p2 = (CategoryLabelPosition) TestUtils.serialised(p1);
+        CategoryLabelPosition p2 = TestUtils.serialised(p1);
         assertEquals(p1, p2);
     }
 

--- a/src/test/java/org/jfree/chart/axis/CategoryLabelPositionsTest.java
+++ b/src/test/java/org/jfree/chart/axis/CategoryLabelPositionsTest.java
@@ -169,7 +169,7 @@ public class CategoryLabelPositionsTest {
     @Test
     public void testSerialization() {
         CategoryLabelPositions p1 = CategoryLabelPositions.STANDARD;
-        CategoryLabelPositions p2 = (CategoryLabelPositions) TestUtils.serialised(p1);
+        CategoryLabelPositions p2 = TestUtils.serialised(p1);
         assertEquals(p1, p2);
     }
 

--- a/src/test/java/org/jfree/chart/axis/CategoryLabelWidthTypeTest.java
+++ b/src/test/java/org/jfree/chart/axis/CategoryLabelWidthTypeTest.java
@@ -77,7 +77,7 @@ public class CategoryLabelWidthTypeTest {
     @Test
     public void testSerialization() {
         CategoryLabelWidthType w1 = CategoryLabelWidthType.RANGE;
-        CategoryLabelWidthType w2 = (CategoryLabelWidthType) TestUtils.serialised(w1);
+        CategoryLabelWidthType w2 = TestUtils.serialised(w1);
         assertEquals(w1, w2);
         assertTrue(w1 == w2);
     }

--- a/src/test/java/org/jfree/chart/axis/CategoryTickTest.java
+++ b/src/test/java/org/jfree/chart/axis/CategoryTickTest.java
@@ -140,7 +140,7 @@ public class CategoryTickTest {
     public void testSerialization() {
         CategoryTick t1 = new CategoryTick("C1", new TextBlock(),
                 TextBlockAnchor.CENTER, TextAnchor.CENTER, 1.5f);
-        CategoryTick t2 = (CategoryTick) TestUtils.serialised(t1);
+        CategoryTick t2 = TestUtils.serialised(t1);
         assertEquals(t1, t2);
     }
 

--- a/src/test/java/org/jfree/chart/axis/CyclicNumberAxisTest.java
+++ b/src/test/java/org/jfree/chart/axis/CyclicNumberAxisTest.java
@@ -135,7 +135,7 @@ public class CyclicNumberAxisTest  {
     @Test
     public void testSerialization() {
         CyclicNumberAxis a1 = new CyclicNumberAxis(10, 0, "Test Axis");
-        CyclicNumberAxis a2 = (CyclicNumberAxis) TestUtils.serialised(a1);
+        CyclicNumberAxis a2 = TestUtils.serialised(a1);
         assertEquals(a1, a2);
     }
 

--- a/src/test/java/org/jfree/chart/axis/DateAxisTest.java
+++ b/src/test/java/org/jfree/chart/axis/DateAxisTest.java
@@ -278,7 +278,7 @@ public class DateAxisTest {
     @Test
     public void testSerialization() {
         DateAxis a1 = new DateAxis("Test Axis");
-        DateAxis a2 = (DateAxis) TestUtils.serialised(a1);
+        DateAxis a2 = TestUtils.serialised(a1);
         assertEquals(a1, a2);
     }
 

--- a/src/test/java/org/jfree/chart/axis/DateTickMarkPositionTest.java
+++ b/src/test/java/org/jfree/chart/axis/DateTickMarkPositionTest.java
@@ -82,7 +82,7 @@ public class DateTickMarkPositionTest {
     @Test
     public void testSerialization() {
         DateTickMarkPosition p1 = DateTickMarkPosition.MIDDLE;
-        DateTickMarkPosition p2 = (DateTickMarkPosition) TestUtils.serialised(p1);
+        DateTickMarkPosition p2 = TestUtils.serialised(p1);
         assertEquals(p1, p2);
         assertTrue(p1 == p2);
     }

--- a/src/test/java/org/jfree/chart/axis/DateTickTest.java
+++ b/src/test/java/org/jfree/chart/axis/DateTickTest.java
@@ -137,7 +137,7 @@ public class DateTickTest {
     public void testSerialization() {
         DateTick t1 = new DateTick(new Date(0L), "Label", TextAnchor.CENTER,
                 TextAnchor.CENTER, 10.0);
-        DateTick t2 = (DateTick) TestUtils.serialised(t1);
+        DateTick t2 = TestUtils.serialised(t1);
         assertEquals(t1, t2);
     }
 

--- a/src/test/java/org/jfree/chart/axis/DateTickUnitTest.java
+++ b/src/test/java/org/jfree/chart/axis/DateTickUnitTest.java
@@ -76,7 +76,7 @@ public class DateTickUnitTest {
     @Test
     public void testSerialization() {
         DateTickUnit a1 = new DateTickUnit(DateTickUnitType.DAY, 7);
-        DateTickUnit a2 = (DateTickUnit) TestUtils.serialised(a1);
+        DateTickUnit a2 = TestUtils.serialised(a1);
         assertEquals(a1, a2);
     }
 

--- a/src/test/java/org/jfree/chart/axis/ExtendedCategoryAxisTest.java
+++ b/src/test/java/org/jfree/chart/axis/ExtendedCategoryAxisTest.java
@@ -152,8 +152,7 @@ public class ExtendedCategoryAxisTest {
         ExtendedCategoryAxis a1 = new ExtendedCategoryAxis("Test");
         a1.setSubLabelPaint(new GradientPaint(1.0f, 2.0f, Color.RED, 3.0f,
                 4.0f, Color.BLUE));
-        ExtendedCategoryAxis a2 = (ExtendedCategoryAxis) 
-                TestUtils.serialised(a1);
+        ExtendedCategoryAxis a2 = TestUtils.serialised(a1);
         assertEquals(a1, a2);
     }
 

--- a/src/test/java/org/jfree/chart/axis/LogAxisTest.java
+++ b/src/test/java/org/jfree/chart/axis/LogAxisTest.java
@@ -146,7 +146,7 @@ public class LogAxisTest {
     @Test
     public void testSerialization() {
         LogAxis a1 = new LogAxis("Test Axis");
-        LogAxis a2 = (LogAxis) TestUtils.serialised(a1);
+        LogAxis a2 = TestUtils.serialised(a1);
         assertEquals(a1, a2);
     }
 

--- a/src/test/java/org/jfree/chart/axis/LogarithmicAxisTest.java
+++ b/src/test/java/org/jfree/chart/axis/LogarithmicAxisTest.java
@@ -100,7 +100,7 @@ public class LogarithmicAxisTest {
     @Test
     public void testSerialization() {
         LogarithmicAxis a1 = new LogarithmicAxis("Test Axis");
-        LogarithmicAxis a2 = (LogarithmicAxis) TestUtils.serialised(a1);
+        LogarithmicAxis a2 = TestUtils.serialised(a1);
         assertEquals(a1, a2);
     }
 

--- a/src/test/java/org/jfree/chart/axis/MarkerAxisBandTest.java
+++ b/src/test/java/org/jfree/chart/axis/MarkerAxisBandTest.java
@@ -109,7 +109,7 @@ public class MarkerAxisBandTest {
     @Test
     public void testSerialization() {
         MarkerAxisBand a1 = new MarkerAxisBand(null, 1.0, 1.0, 1.0, 1.0, null);
-        MarkerAxisBand a2 = (MarkerAxisBand) TestUtils.serialised(a1);
+        MarkerAxisBand a2 = TestUtils.serialised(a1);
         assertEquals(a1, a2);
     }
 

--- a/src/test/java/org/jfree/chart/axis/ModuloAxisTest.java
+++ b/src/test/java/org/jfree/chart/axis/ModuloAxisTest.java
@@ -96,7 +96,7 @@ public class ModuloAxisTest {
     @Test
     public void testSerialization() {
         ModuloAxis a1 = new ModuloAxis("Test", new Range(0.0, 1.0));
-        ModuloAxis a2 = (ModuloAxis) TestUtils.serialised(a1);
+        ModuloAxis a2 = TestUtils.serialised(a1);
         assertEquals(a1, a2);
     }
 

--- a/src/test/java/org/jfree/chart/axis/MonthDateFormatTest.java
+++ b/src/test/java/org/jfree/chart/axis/MonthDateFormatTest.java
@@ -141,7 +141,7 @@ public class MonthDateFormatTest {
     @Test
     public void testSerialization() {
         MonthDateFormat mf1 = new MonthDateFormat();
-        MonthDateFormat mf2 = (MonthDateFormat) TestUtils.serialised(mf1);
+        MonthDateFormat mf2 = TestUtils.serialised(mf1);
         assertTrue(mf1.equals(mf2));
     }
 

--- a/src/test/java/org/jfree/chart/axis/NumberAxisTest.java
+++ b/src/test/java/org/jfree/chart/axis/NumberAxisTest.java
@@ -163,7 +163,7 @@ public class NumberAxisTest {
     @Test
     public void testSerialization() {
         NumberAxis a1 = new NumberAxis("Test Axis");
-        NumberAxis a2 = (NumberAxis) TestUtils.serialised(a1);
+        NumberAxis a2 = TestUtils.serialised(a1);
         assertEquals(a1, a2);
     }
 

--- a/src/test/java/org/jfree/chart/axis/NumberTickUnitTest.java
+++ b/src/test/java/org/jfree/chart/axis/NumberTickUnitTest.java
@@ -99,7 +99,7 @@ public class NumberTickUnitTest {
     @Test
     public void testSerialization() {
         NumberTickUnit t1 = new NumberTickUnit(1.23, new DecimalFormat("0.00"));
-        NumberTickUnit t2 = (NumberTickUnit) TestUtils.serialised(t1);
+        NumberTickUnit t2 = TestUtils.serialised(t1);
         assertEquals(t1, t2);
     }
 

--- a/src/test/java/org/jfree/chart/axis/PeriodAxisLabelInfoTest.java
+++ b/src/test/java/org/jfree/chart/axis/PeriodAxisLabelInfoTest.java
@@ -171,7 +171,7 @@ public class PeriodAxisLabelInfoTest {
     public void testSerialization() {
         PeriodAxisLabelInfo info1 = new PeriodAxisLabelInfo(Day.class,
                 new SimpleDateFormat("d"));
-        PeriodAxisLabelInfo info2 = (PeriodAxisLabelInfo) TestUtils.serialised(info1);
+        PeriodAxisLabelInfo info2 = TestUtils.serialised(info1);
         assertEquals(info1, info2);
     }
 

--- a/src/test/java/org/jfree/chart/axis/PeriodAxisTest.java
+++ b/src/test/java/org/jfree/chart/axis/PeriodAxisTest.java
@@ -234,7 +234,7 @@ public class PeriodAxisTest implements AxisChangeListener {
     @Test
     public void testSerialization() {
         PeriodAxis a1 = new PeriodAxis("Test Axis");
-        PeriodAxis a2 = (PeriodAxis) TestUtils.serialised(a1);
+        PeriodAxis a2 = TestUtils.serialised(a1);
         boolean b = a1.equals(a2);
         assertTrue(b);
     }

--- a/src/test/java/org/jfree/chart/axis/QuarterDateFormatTest.java
+++ b/src/test/java/org/jfree/chart/axis/QuarterDateFormatTest.java
@@ -120,7 +120,7 @@ public class QuarterDateFormatTest {
     public void testSerialization() {
         QuarterDateFormat qf1 = new QuarterDateFormat(TimeZone.getTimeZone(
                 "GMT"), new String[] {"1", "2", "3", "4"});
-        QuarterDateFormat qf2 = (QuarterDateFormat) TestUtils.serialised(qf1);
+        QuarterDateFormat qf2 = TestUtils.serialised(qf1);
         assertEquals(qf1, qf2);
     }
 

--- a/src/test/java/org/jfree/chart/axis/StandardTickUnitSourceTest.java
+++ b/src/test/java/org/jfree/chart/axis/StandardTickUnitSourceTest.java
@@ -63,7 +63,7 @@ public class StandardTickUnitSourceTest {
     @Test
     public void testSerialization() {
         StandardTickUnitSource t1 = new StandardTickUnitSource();
-        StandardTickUnitSource t2 = (StandardTickUnitSource) TestUtils.serialised(t1);
+        StandardTickUnitSource t2 = TestUtils.serialised(t1);
         assertEquals(t1, t2);
     }
 

--- a/src/test/java/org/jfree/chart/axis/SubCategoryAxisTest.java
+++ b/src/test/java/org/jfree/chart/axis/SubCategoryAxisTest.java
@@ -121,7 +121,7 @@ public class SubCategoryAxisTest {
     public void testSerialization() {
         SubCategoryAxis a1 = new SubCategoryAxis("Test Axis");
         a1.addSubCategory("SubCategoryA");
-        SubCategoryAxis a2 = (SubCategoryAxis) TestUtils.serialised(a1);
+        SubCategoryAxis a2 = TestUtils.serialised(a1);
         assertEquals(a1, a2);
     }
 

--- a/src/test/java/org/jfree/chart/axis/SymbolAxisTest.java
+++ b/src/test/java/org/jfree/chart/axis/SymbolAxisTest.java
@@ -57,7 +57,7 @@ public class SymbolAxisTest {
     public void testSerialization() {
         String[] tickLabels = new String[] {"One", "Two", "Three"};
         SymbolAxis a1 = new SymbolAxis("Test Axis", tickLabels);
-        SymbolAxis a2 = (SymbolAxis) TestUtils.serialised(a1);
+        SymbolAxis a2 = TestUtils.serialised(a1);
         assertEquals(a1, a2);
     }
 

--- a/src/test/java/org/jfree/chart/axis/TickUnitsTest.java
+++ b/src/test/java/org/jfree/chart/axis/TickUnitsTest.java
@@ -55,7 +55,7 @@ public class TickUnitsTest {
     public void testSerialization() {
         TickUnits t1 = new TickUnits();
         t1.add(new NumberTickUnit(10, new DecimalFormat("0.00")));
-        TickUnits t2 = (TickUnits) TestUtils.serialised(t1);
+        TickUnits t2 = TestUtils.serialised(t1);
         assertEquals(t1, t2);
     }
 

--- a/src/test/java/org/jfree/chart/block/AbstractBlockTest.java
+++ b/src/test/java/org/jfree/chart/block/AbstractBlockTest.java
@@ -142,7 +142,7 @@ public class AbstractBlockTest{
     @Test
     public void testSerialization() {
         EmptyBlock b1 = new EmptyBlock(1.0, 2.0);
-        EmptyBlock b2 = (EmptyBlock) TestUtils.serialised(b1);
+        EmptyBlock b2 = TestUtils.serialised(b1);
         assertEquals(b1, b2);
     }
 

--- a/src/test/java/org/jfree/chart/block/BlockBorderTest.java
+++ b/src/test/java/org/jfree/chart/block/BlockBorderTest.java
@@ -100,7 +100,7 @@ public class BlockBorderTest {
         BlockBorder b1 = new BlockBorder(new RectangleInsets(1.0, 2.0, 3.0,
                 4.0), new GradientPaint(1.0f, 2.0f, Color.RED, 3.0f, 4.0f,
                 Color.YELLOW));
-        BlockBorder b2 = (BlockBorder) TestUtils.serialised(b1);
+        BlockBorder b2 = TestUtils.serialised(b1);
         assertEquals(b1, b2);
     }
 

--- a/src/test/java/org/jfree/chart/block/BlockContainerTest.java
+++ b/src/test/java/org/jfree/chart/block/BlockContainerTest.java
@@ -89,7 +89,7 @@ public class BlockContainerTest {
     public void testSerialization() {
         BlockContainer c1 = new BlockContainer();
         c1.add(new EmptyBlock(1.2, 3.4));
-        BlockContainer c2 = (BlockContainer) TestUtils.serialised(c1);
+        BlockContainer c2 = TestUtils.serialised(c1);
         assertEquals(c1, c2);
     }
 

--- a/src/test/java/org/jfree/chart/block/BorderArrangementTest.java
+++ b/src/test/java/org/jfree/chart/block/BorderArrangementTest.java
@@ -108,7 +108,7 @@ public class BorderArrangementTest {
     @Test
     public void testSerialization() {
         BorderArrangement b1 = new BorderArrangement();
-        BorderArrangement b2 = (BorderArrangement) TestUtils.serialised(b1);
+        BorderArrangement b2 = TestUtils.serialised(b1);
         assertEquals(b1, b2);
     }
 

--- a/src/test/java/org/jfree/chart/block/ColorBlockTest.java
+++ b/src/test/java/org/jfree/chart/block/ColorBlockTest.java
@@ -116,7 +116,7 @@ public class ColorBlockTest {
         GradientPaint gp = new GradientPaint(1.0f, 2.0f, Color.RED, 3.0f, 4.0f,
                 Color.BLUE);
         ColorBlock b1 = new ColorBlock(gp, 1.0, 2.0);
-        ColorBlock b2 = (ColorBlock) TestUtils.serialised(b1);
+        ColorBlock b2 = TestUtils.serialised(b1);
         assertEquals(b1, b2);
     }
 

--- a/src/test/java/org/jfree/chart/block/ColumnArrangementTest.java
+++ b/src/test/java/org/jfree/chart/block/ColumnArrangementTest.java
@@ -108,7 +108,7 @@ public class ColumnArrangementTest {
     public void testSerialization() {
         FlowArrangement f1 = new FlowArrangement(HorizontalAlignment.LEFT,
                 VerticalAlignment.TOP, 1.0, 2.0);
-        FlowArrangement f2 = (FlowArrangement) TestUtils.serialised(f1);
+        FlowArrangement f2 = TestUtils.serialised(f1);
         assertEquals(f1, f2);
     }
 

--- a/src/test/java/org/jfree/chart/block/EmptyBlockTest.java
+++ b/src/test/java/org/jfree/chart/block/EmptyBlockTest.java
@@ -95,7 +95,7 @@ public class EmptyBlockTest {
     @Test
     public void testSerialization() {
         EmptyBlock b1 = new EmptyBlock(1.0, 2.0);
-        EmptyBlock b2 = (EmptyBlock) TestUtils.serialised(b1);
+        EmptyBlock b2 = TestUtils.serialised(b1);
         assertEquals(b1, b2);
     }
 

--- a/src/test/java/org/jfree/chart/block/FlowArrangementTest.java
+++ b/src/test/java/org/jfree/chart/block/FlowArrangementTest.java
@@ -109,7 +109,7 @@ public class FlowArrangementTest {
     public void testSerialization() {
         FlowArrangement f1 = new FlowArrangement(HorizontalAlignment.LEFT,
                 VerticalAlignment.TOP, 1.0, 2.0);
-        FlowArrangement f2 = (FlowArrangement) TestUtils.serialised(f1);
+        FlowArrangement f2 = TestUtils.serialised(f1);
         assertEquals(f1, f2);
     }
 

--- a/src/test/java/org/jfree/chart/block/GridArrangementTest.java
+++ b/src/test/java/org/jfree/chart/block/GridArrangementTest.java
@@ -87,7 +87,7 @@ public class GridArrangementTest {
     @Test
     public void testSerialization() {
         GridArrangement f1 = new GridArrangement(33, 44);
-        GridArrangement f2 = (GridArrangement) TestUtils.serialised(f1);
+        GridArrangement f2 = TestUtils.serialised(f1);
         assertEquals(f1, f2);
     }
 

--- a/src/test/java/org/jfree/chart/block/LabelBlockTest.java
+++ b/src/test/java/org/jfree/chart/block/LabelBlockTest.java
@@ -131,7 +131,7 @@ public class LabelBlockTest {
                 Color.BLUE);
         LabelBlock b1 = new LabelBlock("ABC", new Font("Dialog",
                 Font.PLAIN, 12), gp);
-        LabelBlock b2 = (LabelBlock) TestUtils.serialised(b1);
+        LabelBlock b2 = TestUtils.serialised(b1);
         assertEquals(b1, b2);
     }
 

--- a/src/test/java/org/jfree/chart/block/LineBorderTest.java
+++ b/src/test/java/org/jfree/chart/block/LineBorderTest.java
@@ -106,7 +106,7 @@ public class LineBorderTest {
         LineBorder b1 = new LineBorder(new GradientPaint(1.0f, 2.0f, Color.RED,
                 3.0f, 4.0f, Color.YELLOW), new BasicStroke(1.0f),
                 new RectangleInsets(1.0, 1.0, 1.0, 1.0));
-        LineBorder b2 = (LineBorder) TestUtils.serialised(b1);
+        LineBorder b2 = TestUtils.serialised(b1);
         assertEquals(b1, b2);
     }
 

--- a/src/test/java/org/jfree/chart/entity/CategoryItemEntityTest.java
+++ b/src/test/java/org/jfree/chart/entity/CategoryItemEntityTest.java
@@ -114,7 +114,7 @@ public class CategoryItemEntityTest {
         d.addValue(4.0, "R2", "C2");
         CategoryItemEntity e1 = new CategoryItemEntity(new Rectangle2D.Double(
                 1.0, 2.0, 3.0, 4.0), "ToolTip", "URL", d, "R2", "C2");
-        CategoryItemEntity e2 = (CategoryItemEntity) TestUtils.serialised(e1);
+        CategoryItemEntity e2 = TestUtils.serialised(e1);
         assertEquals(e1, e2);
     }
 

--- a/src/test/java/org/jfree/chart/entity/CategoryItemEntityTest.java
+++ b/src/test/java/org/jfree/chart/entity/CategoryItemEntityTest.java
@@ -30,7 +30,7 @@
  * (C) Copyright 2004-2021, by David Gilbert and Contributors.
  *
  * Original Author:  David Gilbert;
- * Contributor(s):   -;
+ * Contributor(s):   Tracy Hiltbrand;
  *
  */
 
@@ -41,6 +41,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.awt.geom.Rectangle2D;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 
 import org.jfree.chart.TestUtils;
 
@@ -51,6 +53,19 @@ import org.junit.jupiter.api.Test;
  * Tests for the {@link CategoryItemEntity} class.
  */
 public class CategoryItemEntityTest {
+
+    /**
+     * Use EqualsVerifier to test that the contract between equals and hashCode
+     * is properly implemented.
+     */
+    @Test
+    public void testEqualsHashcode() {
+        EqualsVerifier.forClass(CategoryItemEntity.class)
+            .withRedefinedSuperclass() // superclass also defines equals/hashCode
+            .suppress(Warning.STRICT_INHERITANCE)
+            .suppress(Warning.NONFINAL_FIELDS)
+            .verify();
+    }
 
     /**
      * Confirm that the equals method can distinguish all the required fields.

--- a/src/test/java/org/jfree/chart/entity/CategoryLabelEntityTest.java
+++ b/src/test/java/org/jfree/chart/entity/CategoryLabelEntityTest.java
@@ -33,7 +33,6 @@
  * Contributor(s):   -;
  *
  */
-
 package org.jfree.chart.entity;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -41,6 +40,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.awt.geom.Rectangle2D;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 
 import org.jfree.chart.TestUtils;
 import org.junit.jupiter.api.Test;
@@ -48,24 +49,40 @@ import org.junit.jupiter.api.Test;
 /**
  * Tests for the {@link CategoryLabelEntity} class.
  */
-public class CategoryLabelEntityTest {
+public class CategoryLabelEntityTest
+{
+
+    /**
+     * Use EqualsVerifier to test that the contract between equals and hashCode
+     * is properly implemented.
+     */
+    @Test
+    public void testEqualsHashcode()
+    {
+        EqualsVerifier.forClass(CategoryLabelEntity.class)
+                .withRedefinedSuperclass() // superclass also defines equals/hashCode
+                .suppress(Warning.STRICT_INHERITANCE)
+                .suppress(Warning.NONFINAL_FIELDS)
+                .verify();
+    }
 
     /**
      * Confirm that the equals method can distinguish all the required fields.
      */
     @Test
-    public void testEquals() {
+    public void testEquals()
+    {
         CategoryLabelEntity e1 = new CategoryLabelEntity("A",
-                new Rectangle2D.Double(1.0, 2.0, 3.0, 4.0), "ToolTip", "URL");
+                                                         new Rectangle2D.Double(1.0, 2.0, 3.0, 4.0), "ToolTip", "URL");
         CategoryLabelEntity e2 = new CategoryLabelEntity("A",
-                new Rectangle2D.Double(1.0, 2.0, 3.0, 4.0), "ToolTip", "URL");
+                                                         new Rectangle2D.Double(1.0, 2.0, 3.0, 4.0), "ToolTip", "URL");
         assertTrue(e1.equals(e2));
 
         e1 = new CategoryLabelEntity("B", new Rectangle2D.Double(1.0, 2.0,
-                3.0, 4.0), "ToolTip", "URL");
+                                                                 3.0, 4.0), "ToolTip", "URL");
         assertFalse(e1.equals(e2));
         e2 = new CategoryLabelEntity("B", new Rectangle2D.Double(1.0, 2.0,
-                3.0, 4.0), "ToolTip", "URL");
+                                                                 3.0, 4.0), "ToolTip", "URL");
         assertTrue(e1.equals(e2));
 
         e1.setArea(new Rectangle2D.Double(4.0, 3.0, 2.0, 1.0));
@@ -88,9 +105,10 @@ public class CategoryLabelEntityTest {
      * Confirm that cloning works.
      */
     @Test
-    public void testCloning() throws CloneNotSupportedException {
+    public void testCloning() throws CloneNotSupportedException
+    {
         CategoryLabelEntity e1 = new CategoryLabelEntity("A",
-                new Rectangle2D.Double(1.0, 2.0, 3.0, 4.0), "ToolTip", "URL");
+                                                         new Rectangle2D.Double(1.0, 2.0, 3.0, 4.0), "ToolTip", "URL");
         CategoryLabelEntity e2 = (CategoryLabelEntity) e1.clone();
         assertTrue(e1 != e2);
         assertTrue(e1.getClass() == e2.getClass());
@@ -101,9 +119,10 @@ public class CategoryLabelEntityTest {
      * Serialize an instance, restore it, and check for equality.
      */
     @Test
-    public void testSerialization() {
+    public void testSerialization()
+    {
         CategoryLabelEntity e1 = new CategoryLabelEntity("A",
-                new Rectangle2D.Double(1.0, 2.0, 3.0, 4.0), "ToolTip", "URL");
+                                                         new Rectangle2D.Double(1.0, 2.0, 3.0, 4.0), "ToolTip", "URL");
         CategoryLabelEntity e2 = TestUtils.serialised(e1);
         assertEquals(e1, e2);
     }

--- a/src/test/java/org/jfree/chart/entity/CategoryLabelEntityTest.java
+++ b/src/test/java/org/jfree/chart/entity/CategoryLabelEntityTest.java
@@ -104,7 +104,7 @@ public class CategoryLabelEntityTest {
     public void testSerialization() {
         CategoryLabelEntity e1 = new CategoryLabelEntity("A",
                 new Rectangle2D.Double(1.0, 2.0, 3.0, 4.0), "ToolTip", "URL");
-        CategoryLabelEntity e2 = (CategoryLabelEntity) TestUtils.serialised(e1);
+        CategoryLabelEntity e2 = TestUtils.serialised(e1);
         assertEquals(e1, e2);
     }
 

--- a/src/test/java/org/jfree/chart/entity/FlowEntityTest.java
+++ b/src/test/java/org/jfree/chart/entity/FlowEntityTest.java
@@ -37,6 +37,8 @@
 package org.jfree.chart.entity;
 
 import java.awt.Rectangle;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 import org.jfree.chart.TestUtils;
 import org.jfree.data.flow.FlowKey;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -48,7 +50,20 @@ import org.junit.jupiter.api.Test;
  * Test class for the {@link FlowEntity} class.
  */
 public class FlowEntityTest {
-    
+
+    /**
+     * Use EqualsVerifier to test that the contract between equals and hashCode
+     * is properly implemented.
+     */
+    @Test
+    public void testEqualsHashCode() {
+        EqualsVerifier.forClass(FlowEntity.class)
+            .withRedefinedSuperclass() // superclass also defines equals/hashCode
+            .suppress(Warning.STRICT_INHERITANCE)
+            .suppress(Warning.NONFINAL_FIELDS)
+            .verify();
+    }
+
     /**
      * Confirm that the equals method can distinguish all the required fields.
      */

--- a/src/test/java/org/jfree/chart/entity/FlowEntityTest.java
+++ b/src/test/java/org/jfree/chart/entity/FlowEntityTest.java
@@ -100,7 +100,7 @@ public class FlowEntityTest {
     @Test
     public void testSerialization() {
         FlowEntity f1 = new FlowEntity(new FlowKey<>(0, "A", "B"), new Rectangle(0, 1, 2, 3), "tt", "uu");
-        FlowEntity f2 = (FlowEntity) TestUtils.serialised(f1);
+        FlowEntity f2 = TestUtils.serialised(f1);
         assertEquals(f1, f2);
     }
  

--- a/src/test/java/org/jfree/chart/entity/LegendItemEntityTest.java
+++ b/src/test/java/org/jfree/chart/entity/LegendItemEntityTest.java
@@ -41,6 +41,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.awt.geom.Rectangle2D;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 
 import org.jfree.chart.TestUtils;
 
@@ -52,6 +54,20 @@ import org.junit.jupiter.api.Test;
  */
 public class LegendItemEntityTest {
 
+    /**
+     * Use EqualsVerifier to test that the contract between equals and hashCode
+     * is properly implemented.
+     */
+    @Test
+    public void testEqualsHashCode()
+    {
+        EqualsVerifier.forClass(LegendItemEntity.class)
+            .withRedefinedSuperclass() // superclass also defines equals/hashCode
+            .suppress(Warning.STRICT_INHERITANCE)
+            .suppress(Warning.NONFINAL_FIELDS)
+            .verify();
+    }
+    
     /**
      * Confirm that the equals method can distinguish all the required fields.
      */

--- a/src/test/java/org/jfree/chart/entity/LegendItemEntityTest.java
+++ b/src/test/java/org/jfree/chart/entity/LegendItemEntityTest.java
@@ -110,7 +110,7 @@ public class LegendItemEntityTest {
     public void testSerialization() {
         LegendItemEntity e1 = new LegendItemEntity(new Rectangle2D.Double(1.0,
                 2.0, 3.0, 4.0));
-        LegendItemEntity e2 = (LegendItemEntity) TestUtils.serialised(e1);
+        LegendItemEntity e2 = TestUtils.serialised(e1);
         assertEquals(e1, e2);
     }
 

--- a/src/test/java/org/jfree/chart/entity/PieSectionEntityTest.java
+++ b/src/test/java/org/jfree/chart/entity/PieSectionEntityTest.java
@@ -41,6 +41,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.awt.geom.Rectangle2D;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 
 import org.jfree.chart.TestUtils;
 
@@ -52,6 +54,20 @@ import org.junit.jupiter.api.Test;
  */
 public class PieSectionEntityTest {
 
+    /**
+     * Use EqualsVerifier to test that the contract between equals and hashCode
+     * is properly implemented.
+     */
+    @Test
+    public void testEqualsHashCode()
+    {
+        EqualsVerifier.forClass(PieSectionEntity.class)
+            .withRedefinedSuperclass() // superclass also defines equals/hashCode
+            .suppress(Warning.STRICT_INHERITANCE)
+            .suppress(Warning.NONFINAL_FIELDS)
+            .verify();
+    }
+    
     /**
      * Confirm that the equals method can distinguish all the required fields.
      */

--- a/src/test/java/org/jfree/chart/entity/PieSectionEntityTest.java
+++ b/src/test/java/org/jfree/chart/entity/PieSectionEntityTest.java
@@ -123,7 +123,7 @@ public class PieSectionEntityTest {
         PieSectionEntity e1 = new PieSectionEntity(new Rectangle2D.Double(1.0,
                 2.0, 3.0, 4.0), new DefaultPieDataset(), 1, 2, "Key",
                 "ToolTip", "URL");
-        PieSectionEntity e2 = (PieSectionEntity) TestUtils.serialised(e1);
+        PieSectionEntity e2 = TestUtils.serialised(e1);
         assertEquals(e1, e2);
     }
 

--- a/src/test/java/org/jfree/chart/entity/StandardEntityCollectionTest.java
+++ b/src/test/java/org/jfree/chart/entity/StandardEntityCollectionTest.java
@@ -105,8 +105,7 @@ public class StandardEntityCollectionTest {
                 "ToolTip", "URL");
         StandardEntityCollection c1 = new StandardEntityCollection();
         c1.add(e1);
-        StandardEntityCollection c2 = (StandardEntityCollection) 
-                TestUtils.serialised(c1);
+        StandardEntityCollection c2 = TestUtils.serialised(c1);
         assertEquals(c1, c2);
     }
 

--- a/src/test/java/org/jfree/chart/entity/TickLabelEntityTest.java
+++ b/src/test/java/org/jfree/chart/entity/TickLabelEntityTest.java
@@ -97,7 +97,7 @@ public class TickLabelEntityTest {
     public void testSerialization() {
         TickLabelEntity e1 = new TickLabelEntity(new Rectangle2D.Double(1.0,
                 2.0, 3.0, 4.0), "ToolTip", "URL");
-        TickLabelEntity e2 = (TickLabelEntity) TestUtils.serialised(e1);
+        TickLabelEntity e2 = TestUtils.serialised(e1);
         assertEquals(e1, e2);
     }
 

--- a/src/test/java/org/jfree/chart/entity/XYItemEntityTest.java
+++ b/src/test/java/org/jfree/chart/entity/XYItemEntityTest.java
@@ -110,7 +110,7 @@ public class XYItemEntityTest {
     public void testSerialization() {
         XYItemEntity e1 = new XYItemEntity(new Rectangle2D.Double(1.0, 2.0,
                 3.0, 4.0), new TimeSeriesCollection(), 1, 9, "ToolTip", "URL");
-        XYItemEntity e2 = (XYItemEntity) TestUtils.serialised(e1);
+        XYItemEntity e2 = TestUtils.serialised(e1);
         assertEquals(e1, e2);
     }
 

--- a/src/test/java/org/jfree/chart/entity/XYItemEntityTest.java
+++ b/src/test/java/org/jfree/chart/entity/XYItemEntityTest.java
@@ -30,7 +30,7 @@
  * (C) Copyright 2004-2021, by David Gilbert and Contributors.
  *
  * Original Author:  David Gilbert;
- * Contributor(s):   -;
+ * Contributor(s):   Tracy Hiltbrand;
  *
  */
 
@@ -41,6 +41,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.awt.geom.Rectangle2D;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 
 import org.jfree.chart.TestUtils;
 
@@ -52,6 +54,19 @@ import org.junit.jupiter.api.Test;
  */
 public class XYItemEntityTest {
 
+    /**
+     * Use EqualsVerifier to test that the contract between equals and hashCode
+     * is properly implemented.
+     */
+    @Test
+    public void testEqualsHashCode()
+    {
+        EqualsVerifier.forClass(XYItemEntity.class)
+                .withRedefinedSuperclass() // superclass also defines equals/hashCode
+                .suppress(Warning.STRICT_INHERITANCE)
+                .suppress(Warning.NONFINAL_FIELDS)
+                .verify();
+    }
     /**
      * Confirm that the equals method can distinguish all the required fields.
      */

--- a/src/test/java/org/jfree/chart/labels/BoxAndWhiskerToolTipGeneratorTest.java
+++ b/src/test/java/org/jfree/chart/labels/BoxAndWhiskerToolTipGeneratorTest.java
@@ -120,8 +120,7 @@ public class BoxAndWhiskerToolTipGeneratorTest {
     @Test
     public void testSerialization() {
         BoxAndWhiskerToolTipGenerator g1 = new BoxAndWhiskerToolTipGenerator();
-        BoxAndWhiskerToolTipGenerator g2 = (BoxAndWhiskerToolTipGenerator) 
-                TestUtils.serialised(g1);
+        BoxAndWhiskerToolTipGenerator g2 = TestUtils.serialised(g1);
         assertEquals(g1, g2);
     }
 

--- a/src/test/java/org/jfree/chart/labels/BoxAndWhiskerXYToolTipGeneratorTest.java
+++ b/src/test/java/org/jfree/chart/labels/BoxAndWhiskerXYToolTipGeneratorTest.java
@@ -142,7 +142,7 @@ public class BoxAndWhiskerXYToolTipGeneratorTest {
     public void testSerialization() {
         BoxAndWhiskerXYToolTipGenerator g1
                 = new BoxAndWhiskerXYToolTipGenerator();
-        BoxAndWhiskerXYToolTipGenerator g2 = (BoxAndWhiskerXYToolTipGenerator) TestUtils.serialised(g1);
+        BoxAndWhiskerXYToolTipGenerator g2 = TestUtils.serialised(g1);
         assertEquals(g1, g2);
     }
 

--- a/src/test/java/org/jfree/chart/labels/BubbleXYItemLabelGeneratorTest.java
+++ b/src/test/java/org/jfree/chart/labels/BubbleXYItemLabelGeneratorTest.java
@@ -169,8 +169,7 @@ public class BubbleXYItemLabelGeneratorTest {
     @Test
     public void testSerialization() {
         BubbleXYItemLabelGenerator g1 = new BubbleXYItemLabelGenerator();
-        BubbleXYItemLabelGenerator g2 = (BubbleXYItemLabelGenerator) 
-                TestUtils.serialised(g1);
+        BubbleXYItemLabelGenerator g2 = TestUtils.serialised(g1);
         assertEquals(g1, g2);
     }
 

--- a/src/test/java/org/jfree/chart/labels/CustomXYItemLabelGeneratorTest.java
+++ b/src/test/java/org/jfree/chart/labels/CustomXYItemLabelGeneratorTest.java
@@ -93,8 +93,7 @@ public class CustomXYItemLabelGeneratorTest {
         CustomXYToolTipGenerator g1 = new CustomXYToolTipGenerator();
         g1.addToolTipSeries(t1);
         g1.addToolTipSeries(t2);
-        CustomXYToolTipGenerator g2 = (CustomXYToolTipGenerator) 
-                TestUtils.serialised(g1);
+        CustomXYToolTipGenerator g2 = TestUtils.serialised(g1);
         assertEquals(g1, g2);
     }
 

--- a/src/test/java/org/jfree/chart/labels/HighLowItemLabelGeneratorTest.java
+++ b/src/test/java/org/jfree/chart/labels/HighLowItemLabelGeneratorTest.java
@@ -117,8 +117,7 @@ public class HighLowItemLabelGeneratorTest {
     @Test
     public void testSerialization() {
         HighLowItemLabelGenerator g1 = new HighLowItemLabelGenerator();
-        HighLowItemLabelGenerator g2 = (HighLowItemLabelGenerator) 
-                TestUtils.serialised(g1);
+        HighLowItemLabelGenerator g2 = TestUtils.serialised(g1);
         assertEquals(g1, g2);
     }
 

--- a/src/test/java/org/jfree/chart/labels/IntervalCategoryItemLabelGeneratorTest.java
+++ b/src/test/java/org/jfree/chart/labels/IntervalCategoryItemLabelGeneratorTest.java
@@ -126,7 +126,7 @@ public class IntervalCategoryItemLabelGeneratorTest {
         IntervalCategoryItemLabelGenerator g1
                 = new IntervalCategoryItemLabelGenerator("{3} - {4}",
                 DateFormat.getInstance());
-        IntervalCategoryItemLabelGenerator g2 = (IntervalCategoryItemLabelGenerator) TestUtils.serialised(g1);
+        IntervalCategoryItemLabelGenerator g2 = TestUtils.serialised(g1);
         assertEquals(g1, g2);
     }
 

--- a/src/test/java/org/jfree/chart/labels/IntervalCategoryToolTipGeneratorTest.java
+++ b/src/test/java/org/jfree/chart/labels/IntervalCategoryToolTipGeneratorTest.java
@@ -141,8 +141,7 @@ public class IntervalCategoryToolTipGeneratorTest {
         IntervalCategoryToolTipGenerator g1
                 = new IntervalCategoryToolTipGenerator("{3} - {4}",
                 DateFormat.getInstance());
-        IntervalCategoryToolTipGenerator g2 = (IntervalCategoryToolTipGenerator)
-                TestUtils.serialised(g1);
+        IntervalCategoryToolTipGenerator g2 = TestUtils.serialised(g1);
         assertEquals(g1, g2);
     }
 

--- a/src/test/java/org/jfree/chart/labels/ItemLabelAnchorTest.java
+++ b/src/test/java/org/jfree/chart/labels/ItemLabelAnchorTest.java
@@ -62,7 +62,7 @@ public class ItemLabelAnchorTest {
     @Test
     public void testSerialization() {
         ItemLabelAnchor a1 = ItemLabelAnchor.INSIDE1;
-        ItemLabelAnchor a2 = (ItemLabelAnchor) TestUtils.serialised(a1);
+        ItemLabelAnchor a2 = TestUtils.serialised(a1);
         assertTrue(a1 == a2);
     }
 

--- a/src/test/java/org/jfree/chart/labels/ItemLabelPositionTest.java
+++ b/src/test/java/org/jfree/chart/labels/ItemLabelPositionTest.java
@@ -62,7 +62,7 @@ public class ItemLabelPositionTest {
     @Test
     public void testSerialization() {
         ItemLabelPosition p1 = new ItemLabelPosition();
-        ItemLabelPosition p2 = (ItemLabelPosition) TestUtils.serialised(p1);
+        ItemLabelPosition p2 = TestUtils.serialised(p1);
         assertEquals(p1, p2);
     }
 

--- a/src/test/java/org/jfree/chart/labels/MultipleXYSeriesLabelGeneratorTest.java
+++ b/src/test/java/org/jfree/chart/labels/MultipleXYSeriesLabelGeneratorTest.java
@@ -126,8 +126,7 @@ public class MultipleXYSeriesLabelGeneratorTest {
         g1.addSeriesLabel(0, "Add0");
         g1.addSeriesLabel(0, "Add0b");
         g1.addSeriesLabel(1, "Add1");
-        MultipleXYSeriesLabelGenerator g2 = (MultipleXYSeriesLabelGenerator) 
-                TestUtils.serialised(g1);
+        MultipleXYSeriesLabelGenerator g2 = TestUtils.serialised(g1);
         assertEquals(g1, g2);
     }
 

--- a/src/test/java/org/jfree/chart/labels/StandardCategoryItemLabelGeneratorTest.java
+++ b/src/test/java/org/jfree/chart/labels/StandardCategoryItemLabelGeneratorTest.java
@@ -157,8 +157,7 @@ public class StandardCategoryItemLabelGeneratorTest {
         StandardCategoryItemLabelGenerator g1
                 = new StandardCategoryItemLabelGenerator("{2}",
                 DateFormat.getInstance());
-        StandardCategoryItemLabelGenerator g2 = (StandardCategoryItemLabelGenerator) 
-                TestUtils.serialised(g1);
+        StandardCategoryItemLabelGenerator g2 = TestUtils.serialised(g1);
         assertEquals(g1, g2);
     }
 

--- a/src/test/java/org/jfree/chart/labels/StandardCategorySeriesLabelGeneratorTest.java
+++ b/src/test/java/org/jfree/chart/labels/StandardCategorySeriesLabelGeneratorTest.java
@@ -129,8 +129,7 @@ public class StandardCategorySeriesLabelGeneratorTest {
     public void testSerialization() {
         StandardCategorySeriesLabelGenerator g1
                 = new StandardCategorySeriesLabelGenerator("{2}");
-        StandardCategorySeriesLabelGenerator g2 = (StandardCategorySeriesLabelGenerator) 
-                TestUtils.serialised(g1);
+        StandardCategorySeriesLabelGenerator g2 = TestUtils.serialised(g1);
         assertEquals(g1, g2);
     }
 

--- a/src/test/java/org/jfree/chart/labels/StandardCategoryToolTipGeneratorTest.java
+++ b/src/test/java/org/jfree/chart/labels/StandardCategoryToolTipGeneratorTest.java
@@ -135,8 +135,7 @@ public class StandardCategoryToolTipGeneratorTest {
         StandardCategoryToolTipGenerator g1
                 = new StandardCategoryToolTipGenerator("{2}",
                 DateFormat.getInstance());
-        StandardCategoryToolTipGenerator g2 = (StandardCategoryToolTipGenerator)
-                TestUtils.serialised(g1);
+        StandardCategoryToolTipGenerator g2 = TestUtils.serialised(g1);
         assertEquals(g1, g2);
     }
 

--- a/src/test/java/org/jfree/chart/labels/StandardPieSectionLabelGeneratorTest.java
+++ b/src/test/java/org/jfree/chart/labels/StandardPieSectionLabelGeneratorTest.java
@@ -149,8 +149,7 @@ public class StandardPieSectionLabelGeneratorTest {
     public void testSerialization() {
         StandardPieSectionLabelGenerator g1
                 = new StandardPieSectionLabelGenerator();
-        StandardPieSectionLabelGenerator g2 = (StandardPieSectionLabelGenerator) 
-                TestUtils.serialised(g1);
+        StandardPieSectionLabelGenerator g2 = TestUtils.serialised(g1);
         assertEquals(g1, g2);
     }
 

--- a/src/test/java/org/jfree/chart/labels/StandardPieToolTipGeneratorTest.java
+++ b/src/test/java/org/jfree/chart/labels/StandardPieToolTipGeneratorTest.java
@@ -139,8 +139,7 @@ public class StandardPieToolTipGeneratorTest {
     @Test
     public void testSerialization() {
         StandardPieToolTipGenerator g1 = new StandardPieToolTipGenerator();
-        StandardPieToolTipGenerator g2 = (StandardPieToolTipGenerator)
-                TestUtils.serialised(g1);
+        StandardPieToolTipGenerator g2 = TestUtils.serialised(g1);
         assertEquals(g1, g2);
     }
 

--- a/src/test/java/org/jfree/chart/labels/StandardXYItemLabelGeneratorTest.java
+++ b/src/test/java/org/jfree/chart/labels/StandardXYItemLabelGeneratorTest.java
@@ -186,8 +186,7 @@ public class StandardXYItemLabelGeneratorTest {
     @Test
     public void testSerialization() {
         StandardXYItemLabelGenerator g1 = new StandardXYItemLabelGenerator();
-        StandardXYItemLabelGenerator g2 = (StandardXYItemLabelGenerator) 
-                TestUtils.serialised(g1);
+        StandardXYItemLabelGenerator g2 = TestUtils.serialised(g1);
         assertEquals(g1, g2);
     }
 

--- a/src/test/java/org/jfree/chart/labels/StandardXYSeriesLabelGeneratorTest.java
+++ b/src/test/java/org/jfree/chart/labels/StandardXYSeriesLabelGeneratorTest.java
@@ -128,8 +128,7 @@ public class StandardXYSeriesLabelGeneratorTest {
     public void testSerialization() {
         StandardXYSeriesLabelGenerator g1
                 = new StandardXYSeriesLabelGenerator("Series {0}");
-        StandardXYSeriesLabelGenerator g2 = (StandardXYSeriesLabelGenerator) 
-                TestUtils.serialised(g1);
+        StandardXYSeriesLabelGenerator g2 = TestUtils.serialised(g1);
         assertEquals(g1, g2);
     }
 }

--- a/src/test/java/org/jfree/chart/labels/StandardXYToolTipGeneratorTest.java
+++ b/src/test/java/org/jfree/chart/labels/StandardXYToolTipGeneratorTest.java
@@ -154,8 +154,7 @@ public class StandardXYToolTipGeneratorTest {
     @Test
     public void testSerialization() {
         StandardXYToolTipGenerator g1 = new StandardXYToolTipGenerator();
-        StandardXYToolTipGenerator g2 = (StandardXYToolTipGenerator) 
-                TestUtils.serialised(g1);
+        StandardXYToolTipGenerator g2 = TestUtils.serialised(g1);
         assertEquals(g1, g2);
     }
 

--- a/src/test/java/org/jfree/chart/labels/StandardXYZToolTipGeneratorTest.java
+++ b/src/test/java/org/jfree/chart/labels/StandardXYZToolTipGeneratorTest.java
@@ -174,8 +174,7 @@ public class StandardXYZToolTipGeneratorTest {
     @Test
     public void testSerialization() {
         StandardXYZToolTipGenerator g1 = new StandardXYZToolTipGenerator();
-        StandardXYZToolTipGenerator g2 = (StandardXYZToolTipGenerator) 
-                TestUtils.serialised(g1);
+        StandardXYZToolTipGenerator g2 = TestUtils.serialised(g1);
         assertEquals(g1, g2);
     }
 

--- a/src/test/java/org/jfree/chart/labels/SymbolicXYItemLabelGeneratorTest.java
+++ b/src/test/java/org/jfree/chart/labels/SymbolicXYItemLabelGeneratorTest.java
@@ -101,8 +101,7 @@ public class SymbolicXYItemLabelGeneratorTest {
     @Test
     public void testSerialization() {
         SymbolicXYItemLabelGenerator g1 = new SymbolicXYItemLabelGenerator();
-        SymbolicXYItemLabelGenerator g2 = (SymbolicXYItemLabelGenerator) 
-                TestUtils.serialised(g1);
+        SymbolicXYItemLabelGenerator g2 = TestUtils.serialised(g1);
         assertEquals(g1, g2);
     }
 

--- a/src/test/java/org/jfree/chart/needle/ArrowNeedleTest.java
+++ b/src/test/java/org/jfree/chart/needle/ArrowNeedleTest.java
@@ -81,7 +81,7 @@ public class ArrowNeedleTest {
     @Test
     public void testSerialization() {
         ArrowNeedle n1 = new ArrowNeedle(false);
-        ArrowNeedle n2 = (ArrowNeedle) TestUtils.serialised(n1);
+        ArrowNeedle n2 = TestUtils.serialised(n1);
         assertTrue(n1.equals(n2));
     }
 

--- a/src/test/java/org/jfree/chart/needle/LineNeedleTest.java
+++ b/src/test/java/org/jfree/chart/needle/LineNeedleTest.java
@@ -75,7 +75,7 @@ public class LineNeedleTest {
     @Test
     public void testSerialization() {
         LineNeedle n1 = new LineNeedle();
-        LineNeedle n2 = (LineNeedle) TestUtils.serialised(n1);
+        LineNeedle n2 = TestUtils.serialised(n1);
         assertTrue(n1.equals(n2));
     }
 

--- a/src/test/java/org/jfree/chart/needle/LongNeedleTest.java
+++ b/src/test/java/org/jfree/chart/needle/LongNeedleTest.java
@@ -75,7 +75,7 @@ public class LongNeedleTest {
     @Test
     public void testSerialization() {
         LongNeedle n1 = new LongNeedle();
-        LongNeedle n2 = (LongNeedle) TestUtils.serialised(n1);
+        LongNeedle n2 = TestUtils.serialised(n1);
         assertTrue(n1.equals(n2));
     }
 

--- a/src/test/java/org/jfree/chart/needle/MiddlePinNeedleTest.java
+++ b/src/test/java/org/jfree/chart/needle/MiddlePinNeedleTest.java
@@ -75,7 +75,7 @@ public class MiddlePinNeedleTest {
     @Test
     public void testSerialization() {
         MiddlePinNeedle n1 = new MiddlePinNeedle();
-        MiddlePinNeedle n2 = (MiddlePinNeedle) TestUtils.serialised(n1);
+        MiddlePinNeedle n2 = TestUtils.serialised(n1);
         assertTrue(n1.equals(n2));
     }
 

--- a/src/test/java/org/jfree/chart/needle/PinNeedleTest.java
+++ b/src/test/java/org/jfree/chart/needle/PinNeedleTest.java
@@ -75,7 +75,7 @@ public class PinNeedleTest {
     @Test
     public void testSerialization() {
         PinNeedle n1 = new PinNeedle();
-        PinNeedle n2 = (PinNeedle) TestUtils.serialised(n1);
+        PinNeedle n2 = TestUtils.serialised(n1);
         assertTrue(n1.equals(n2));
     }
 

--- a/src/test/java/org/jfree/chart/needle/PlumNeedleTest.java
+++ b/src/test/java/org/jfree/chart/needle/PlumNeedleTest.java
@@ -75,7 +75,7 @@ public class PlumNeedleTest {
     @Test
     public void testSerialization() {
         PlumNeedle n1 = new PlumNeedle();
-        PlumNeedle n2 = (PlumNeedle) TestUtils.serialised(n1);
+        PlumNeedle n2 = TestUtils.serialised(n1);
         assertTrue(n1.equals(n2));
     }
 

--- a/src/test/java/org/jfree/chart/needle/PointerNeedleTest.java
+++ b/src/test/java/org/jfree/chart/needle/PointerNeedleTest.java
@@ -75,7 +75,7 @@ public class PointerNeedleTest {
     @Test
     public void testSerialization() {
         PointerNeedle n1 = new PointerNeedle();
-        PointerNeedle n2 = (PointerNeedle) TestUtils.serialised(n1);
+        PointerNeedle n2 = TestUtils.serialised(n1);
         assertTrue(n1.equals(n2));
     }
 

--- a/src/test/java/org/jfree/chart/needle/ShipNeedleTest.java
+++ b/src/test/java/org/jfree/chart/needle/ShipNeedleTest.java
@@ -75,7 +75,7 @@ public class ShipNeedleTest {
     @Test
     public void testSerialization() {
         ShipNeedle n1 = new ShipNeedle();
-        ShipNeedle n2 = (ShipNeedle) TestUtils.serialised(n1);
+        ShipNeedle n2 = TestUtils.serialised(n1);
         assertTrue(n1.equals(n2));
     }
 

--- a/src/test/java/org/jfree/chart/needle/WindNeedleTest.java
+++ b/src/test/java/org/jfree/chart/needle/WindNeedleTest.java
@@ -75,7 +75,7 @@ public class WindNeedleTest {
     @Test
     public void testSerialization() {
         WindNeedle n1 = new WindNeedle();
-        WindNeedle n2 = (WindNeedle) TestUtils.serialised(n1);
+        WindNeedle n2 = TestUtils.serialised(n1);
         assertTrue(n1.equals(n2));
     }
 

--- a/src/test/java/org/jfree/chart/panel/CrosshairOverlayTest.java
+++ b/src/test/java/org/jfree/chart/panel/CrosshairOverlayTest.java
@@ -73,7 +73,7 @@ public class CrosshairOverlayTest {
         o1.addDomainCrosshair(new Crosshair(99.9));
         o1.addRangeCrosshair(new Crosshair(1.23, new GradientPaint(1.0f, 2.0f,
                 Color.RED, 3.0f, 4.0f, Color.BLUE), new BasicStroke(1.1f)));
-        CrosshairOverlay o2 = (CrosshairOverlay) TestUtils.serialised(o1);
+        CrosshairOverlay o2 = TestUtils.serialised(o1);
         assertEquals(o1, o2);
     }
 

--- a/src/test/java/org/jfree/chart/plot/CategoryMarkerTest.java
+++ b/src/test/java/org/jfree/chart/plot/CategoryMarkerTest.java
@@ -154,7 +154,7 @@ public class CategoryMarkerTest implements MarkerChangeListener {
         CategoryMarker m1 = new CategoryMarker("A", new GradientPaint(1.0f,
                 2.0f, Color.WHITE, 3.0f, 4.0f, Color.YELLOW),
                 new BasicStroke(1.1f));
-        CategoryMarker m2 = (CategoryMarker) TestUtils.serialised(m1);
+        CategoryMarker m2 = TestUtils.serialised(m1);
         assertEquals(m1, m2);
     }
 

--- a/src/test/java/org/jfree/chart/plot/CategoryPlotTest.java
+++ b/src/test/java/org/jfree/chart/plot/CategoryPlotTest.java
@@ -697,7 +697,7 @@ public class CategoryPlotTest {
         CategoryPlot p1 = new CategoryPlot(dataset, domainAxis, rangeAxis,
                 renderer);
         p1.setOrientation(PlotOrientation.HORIZONTAL);
-        CategoryPlot p2 = (CategoryPlot) TestUtils.serialised(p1);
+        CategoryPlot p2 = TestUtils.serialised(p1);
         assertTrue(p1.equals(p2));
     }
 
@@ -713,7 +713,7 @@ public class CategoryPlotTest {
         CategoryPlot p1 = new CategoryPlot(data, domainAxis, rangeAxis,
                 renderer);
         p1.setOrientation(PlotOrientation.VERTICAL);
-        CategoryPlot p2 = (CategoryPlot) TestUtils.serialised(p1);
+        CategoryPlot p2 = TestUtils.serialised(p1);
         assertEquals(p1, p2);
     }
 
@@ -726,7 +726,7 @@ public class CategoryPlotTest {
         JFreeChart chart = ChartFactory.createBarChart(
                 "Test Chart", "Category Axis", "Value Axis", dataset,
                 PlotOrientation.VERTICAL, true, true, false);
-        JFreeChart chart2 = (JFreeChart) TestUtils.serialised(chart);
+        JFreeChart chart2 = TestUtils.serialised(chart);
 
         // now check that the chart is usable...
         try {
@@ -749,7 +749,7 @@ public class CategoryPlotTest {
         CategoryPlot plot = (CategoryPlot) chart.getPlot();
         plot.addRangeMarker(new ValueMarker(1.1), Layer.FOREGROUND);
         plot.addRangeMarker(new IntervalMarker(2.2, 3.3), Layer.BACKGROUND);
-        JFreeChart chart2 = (JFreeChart) TestUtils.serialised(chart);
+        JFreeChart chart2 = TestUtils.serialised(chart);
         assertEquals(chart, chart2);
 
         // now check that the chart is usable...
@@ -782,7 +782,7 @@ public class CategoryPlotTest {
         p1.setDomainAxis(1, domainAxis2);
         p1.setRangeAxis(1, rangeAxis2);
         p1.setRenderer(1, renderer2);
-        CategoryPlot p2 = (CategoryPlot) TestUtils.serialised(p1);
+        CategoryPlot p2 = TestUtils.serialised(p1);
         assertEquals(p1, p2);
 
         // now check that all datasets, renderers and axes are being listened

--- a/src/test/java/org/jfree/chart/plot/CombinedDomainCategoryPlotTest.java
+++ b/src/test/java/org/jfree/chart/plot/CombinedDomainCategoryPlotTest.java
@@ -121,8 +121,7 @@ public class CombinedDomainCategoryPlotTest implements ChartChangeListener {
     @Test
     public void testSerialization() {
         CombinedDomainCategoryPlot plot1 = createPlot();
-        CombinedDomainCategoryPlot plot2 = (CombinedDomainCategoryPlot) 
-                TestUtils.serialised(plot1);
+        CombinedDomainCategoryPlot plot2 = TestUtils.serialised(plot1);
         assertEquals(plot1, plot2);
     }
 

--- a/src/test/java/org/jfree/chart/plot/CombinedDomainXYPlotTest.java
+++ b/src/test/java/org/jfree/chart/plot/CombinedDomainXYPlotTest.java
@@ -134,8 +134,7 @@ public class CombinedDomainXYPlotTest implements ChartChangeListener {
     @Test
     public void testSerialization() {
         CombinedDomainXYPlot plot1 = createPlot();
-        CombinedDomainXYPlot plot2 = (CombinedDomainXYPlot) 
-                TestUtils.serialised(plot1);
+        CombinedDomainXYPlot plot2 = TestUtils.serialised(plot1);
         assertEquals(plot1, plot2);
     }
 
@@ -148,7 +147,7 @@ public class CombinedDomainXYPlotTest implements ChartChangeListener {
         CombinedDomainXYPlot plot = createPlot();
         JFreeChart chart = new JFreeChart(plot);
         chart.addChangeListener(this);
-        XYPlot subplot1 = (XYPlot) plot.getSubplots().get(0);
+        XYPlot subplot1 = plot.getSubplots().get(0);
         NumberAxis yAxis = (NumberAxis) subplot1.getRangeAxis();
         yAxis.setAutoRangeIncludesZero(!yAxis.getAutoRangeIncludesZero());
         assertEquals(1, this.events.size());

--- a/src/test/java/org/jfree/chart/plot/CombinedRangeCategoryPlotTest.java
+++ b/src/test/java/org/jfree/chart/plot/CombinedRangeCategoryPlotTest.java
@@ -104,8 +104,7 @@ public class CombinedRangeCategoryPlotTest implements ChartChangeListener {
     @Test
     public void testSerialization() {
         CombinedRangeCategoryPlot plot1 = createPlot();
-        CombinedRangeCategoryPlot plot2 = (CombinedRangeCategoryPlot) 
-                TestUtils.serialised(plot1);
+        CombinedRangeCategoryPlot plot2 = TestUtils.serialised(plot1);
         assertEquals(plot1, plot2);
     }
 

--- a/src/test/java/org/jfree/chart/plot/CombinedRangeXYPlotTest.java
+++ b/src/test/java/org/jfree/chart/plot/CombinedRangeXYPlotTest.java
@@ -122,8 +122,7 @@ public class CombinedRangeXYPlotTest implements ChartChangeListener {
     @Test
     public void testSerialization() {
         CombinedRangeXYPlot plot1 = createPlot();
-        CombinedRangeXYPlot plot2 = (CombinedRangeXYPlot) 
-                TestUtils.serialised(plot1);
+        CombinedRangeXYPlot plot2 = TestUtils.serialised(plot1);
         assertEquals(plot1, plot2);
     }
 
@@ -136,7 +135,7 @@ public class CombinedRangeXYPlotTest implements ChartChangeListener {
         CombinedRangeXYPlot plot = createPlot();
         JFreeChart chart = new JFreeChart(plot);
         chart.addChangeListener(this);
-        XYPlot subplot1 = (XYPlot) plot.getSubplots().get(0);
+        XYPlot subplot1 = plot.getSubplots().get(0);
         NumberAxis xAxis = (NumberAxis) subplot1.getDomainAxis();
         xAxis.setAutoRangeIncludesZero(!xAxis.getAutoRangeIncludesZero());
         assertEquals(1, this.events.size());

--- a/src/test/java/org/jfree/chart/plot/CompassPlotTest.java
+++ b/src/test/java/org/jfree/chart/plot/CompassPlotTest.java
@@ -118,7 +118,7 @@ public class CompassPlotTest {
                 1.0f, Color.GREEN));
         p1.setRoseHighlightPaint(new GradientPaint(4.0f, 3.0f, Color.RED, 2.0f,
                 1.0f, Color.GREEN));
-        CompassPlot p2 = (CompassPlot) TestUtils.serialised(p1);
+        CompassPlot p2 = TestUtils.serialised(p1);
         assertEquals(p1, p2);
     }
 

--- a/src/test/java/org/jfree/chart/plot/CrosshairTest.java
+++ b/src/test/java/org/jfree/chart/plot/CrosshairTest.java
@@ -187,7 +187,7 @@ public class CrosshairTest {
     public void testSerialization() {
         Crosshair c1 = new Crosshair(1.0, new GradientPaint(1.0f, 2.0f,
                 Color.RED, 3.0f, 4.0f, Color.BLUE), new BasicStroke(1.0f));
-        Crosshair c2 = (Crosshair) TestUtils.serialised(c1);
+        Crosshair c2 = TestUtils.serialised(c1);
         assertEquals(c1, c2);
     }
 

--- a/src/test/java/org/jfree/chart/plot/DefaultDrawingSupplierTest.java
+++ b/src/test/java/org/jfree/chart/plot/DefaultDrawingSupplierTest.java
@@ -180,8 +180,7 @@ public class DefaultDrawingSupplierTest {
     @Test
     public void testSerialization() {
         DefaultDrawingSupplier r1 = new DefaultDrawingSupplier();
-        DefaultDrawingSupplier r2 = (DefaultDrawingSupplier) 
-                TestUtils.serialised(r1);
+        DefaultDrawingSupplier r2 = TestUtils.serialised(r1);
         assertEquals(r1, r2);
     }
 

--- a/src/test/java/org/jfree/chart/plot/FastScatterPlotTest.java
+++ b/src/test/java/org/jfree/chart/plot/FastScatterPlotTest.java
@@ -189,7 +189,7 @@ public class FastScatterPlotTest {
         ValueAxis domainAxis = new NumberAxis("X");
         ValueAxis rangeAxis = new NumberAxis("Y");
         FastScatterPlot p1 = new FastScatterPlot(data, domainAxis, rangeAxis);
-        FastScatterPlot p2 = (FastScatterPlot) TestUtils.serialised(p1);
+        FastScatterPlot p2 = TestUtils.serialised(p1);
         assertEquals(p1, p2);
     }
 

--- a/src/test/java/org/jfree/chart/plot/IntervalMarkerTest.java
+++ b/src/test/java/org/jfree/chart/plot/IntervalMarkerTest.java
@@ -114,7 +114,7 @@ public class IntervalMarkerTest implements MarkerChangeListener {
     @Test
     public void testSerialization() {
         IntervalMarker m1 = new IntervalMarker(45.0, 50.0);
-        IntervalMarker m2 = (IntervalMarker) TestUtils.serialised(m1);
+        IntervalMarker m2 = TestUtils.serialised(m1);
         assertEquals(m1, m2);
     }
 

--- a/src/test/java/org/jfree/chart/plot/MeterIntervalTest.java
+++ b/src/test/java/org/jfree/chart/plot/MeterIntervalTest.java
@@ -98,7 +98,7 @@ public class MeterIntervalTest {
     @Test
     public void testSerialization() {
         MeterInterval m1 = new MeterInterval("X", new Range(1.0, 2.0));
-        MeterInterval m2 = (MeterInterval) TestUtils.serialised(m1);
+        MeterInterval m2 = TestUtils.serialised(m1);
         assertEquals(m1, m2);
     }
 

--- a/src/test/java/org/jfree/chart/plot/MeterPlotTest.java
+++ b/src/test/java/org/jfree/chart/plot/MeterPlotTest.java
@@ -235,7 +235,7 @@ public class MeterPlotTest {
                 3.0f, 4.0f, Color.BLUE));
         p1.setTickPaint(new GradientPaint(1.0f, 2.0f, Color.RED,
                 3.0f, 4.0f, Color.BLUE));
-        MeterPlot p2 = (MeterPlot) TestUtils.serialised(p1);
+        MeterPlot p2 = TestUtils.serialised(p1);
         assertEquals(p1, p2);
     }
 
@@ -245,7 +245,7 @@ public class MeterPlotTest {
     @Test
     public void testSerialization2() {
         MeterPlot p1 = new MeterPlot(new DefaultValueDataset(1.23));
-        MeterPlot p2 = (MeterPlot) TestUtils.serialised(p1);
+        MeterPlot p2 = TestUtils.serialised(p1);
         assertEquals(p1, p2);
 
     }

--- a/src/test/java/org/jfree/chart/plot/MultiplePiePlotTest.java
+++ b/src/test/java/org/jfree/chart/plot/MultiplePiePlotTest.java
@@ -161,7 +161,7 @@ public class MultiplePiePlotTest implements PlotChangeListener {
         MultiplePiePlot p1 = new MultiplePiePlot(null);
         p1.setAggregatedItemsPaint(new GradientPaint(1.0f, 2.0f, Color.YELLOW,
                 3.0f, 4.0f, Color.RED));
-        MultiplePiePlot p2 = (MultiplePiePlot) TestUtils.serialised(p1);
+        MultiplePiePlot p2 = TestUtils.serialised(p1);
         assertEquals(p1, p2);
     }
 

--- a/src/test/java/org/jfree/chart/plot/PieLabelRecordTest.java
+++ b/src/test/java/org/jfree/chart/plot/PieLabelRecordTest.java
@@ -115,7 +115,7 @@ public class PieLabelRecordTest {
     public void testSerialization() {
         PieLabelRecord p1 = new PieLabelRecord("A", 1.0, 2.0, new TextBox("B"),
                 3.0, 4.0, 5.0);
-        PieLabelRecord p2 = (PieLabelRecord) TestUtils.serialised(p1);
+        PieLabelRecord p2 = TestUtils.serialised(p1);
         boolean b = p1.equals(p2);
         assertTrue(b);
     }

--- a/src/test/java/org/jfree/chart/plot/PiePlotTest.java
+++ b/src/test/java/org/jfree/chart/plot/PiePlotTest.java
@@ -509,7 +509,7 @@ public class PiePlotTest {
     @Test
     public void testSerialization() {
         PiePlot p1 = new PiePlot(null);
-        PiePlot p2 = (PiePlot) TestUtils.serialised(p1);
+        PiePlot p2 = TestUtils.serialised(p1);
         assertEquals(p1, p2);
     }
 

--- a/src/test/java/org/jfree/chart/plot/PlotOrientationTest.java
+++ b/src/test/java/org/jfree/chart/plot/PlotOrientationTest.java
@@ -69,8 +69,7 @@ public class PlotOrientationTest {
     @Test
     public void testSerialization() {
         PlotOrientation orientation1 = PlotOrientation.HORIZONTAL;
-        PlotOrientation orientation2 = (PlotOrientation) 
-                TestUtils.serialised(orientation1);
+        PlotOrientation orientation2 = TestUtils.serialised(orientation1);
         assertEquals(orientation1, orientation2);
         boolean same = orientation1 == orientation2;
         assertEquals(true, same);

--- a/src/test/java/org/jfree/chart/plot/PlotRenderingInfoTest.java
+++ b/src/test/java/org/jfree/chart/plot/PlotRenderingInfoTest.java
@@ -113,7 +113,7 @@ public class PlotRenderingInfoTest {
     @Test
     public void testSerialization() {
         PlotRenderingInfo p1 = new PlotRenderingInfo(new ChartRenderingInfo());
-        PlotRenderingInfo p2 = (PlotRenderingInfo) TestUtils.serialised(p1);
+        PlotRenderingInfo p2 = TestUtils.serialised(p1);
         assertEquals(p1, p2);
     }
 

--- a/src/test/java/org/jfree/chart/plot/PolarPlotTest.java
+++ b/src/test/java/org/jfree/chart/plot/PolarPlotTest.java
@@ -255,7 +255,7 @@ public class PolarPlotTest {
                 4.0f, Color.BLUE));
         p1.setRadiusGridlinePaint(new GradientPaint(1.0f, 2.0f, Color.RED, 3.0f,
                 4.0f, Color.BLUE));
-        PolarPlot p2 = (PolarPlot) TestUtils.serialised(p1);
+        PolarPlot p2 = TestUtils.serialised(p1);
         assertEquals(p1, p2);
     }
 

--- a/src/test/java/org/jfree/chart/plot/RingPlotTest.java
+++ b/src/test/java/org/jfree/chart/plot/RingPlotTest.java
@@ -157,7 +157,7 @@ public class RingPlotTest {
         GradientPaint gp = new GradientPaint(1.0f, 2.0f, Color.YELLOW,
                 3.0f, 4.0f, Color.RED);
         p1.setSeparatorPaint(gp);
-        RingPlot p2 = (RingPlot) TestUtils.serialised(p1);
+        RingPlot p2 = TestUtils.serialised(p1);
         assertEquals(p1, p2);
     }
 

--- a/src/test/java/org/jfree/chart/plot/SpiderWebPlotTest.java
+++ b/src/test/java/org/jfree/chart/plot/SpiderWebPlotTest.java
@@ -290,7 +290,7 @@ public class SpiderWebPlotTest {
     @Test
     public void testSerialization() {
         SpiderWebPlot p1 = new SpiderWebPlot(new DefaultCategoryDataset());
-        SpiderWebPlot p2 = (SpiderWebPlot) TestUtils.serialised(p1);
+        SpiderWebPlot p2 = TestUtils.serialised(p1);
         assertEquals(p1, p2);
     }
 

--- a/src/test/java/org/jfree/chart/plot/ThermometerPlotTest.java
+++ b/src/test/java/org/jfree/chart/plot/ThermometerPlotTest.java
@@ -179,7 +179,7 @@ public class ThermometerPlotTest {
     @Test
     public void testSerialization() {
         ThermometerPlot p1 = new ThermometerPlot();
-        ThermometerPlot p2 = (ThermometerPlot) TestUtils.serialised(p1);
+        ThermometerPlot p2 = TestUtils.serialised(p1);
         assertTrue(p1.equals(p2));
     }
 
@@ -191,7 +191,7 @@ public class ThermometerPlotTest {
         ThermometerPlot p1 = new ThermometerPlot();
         p1.setSubrangePaint(1, new GradientPaint(1.0f, 2.0f, Color.RED, 3.0f,
                 4.0f, Color.BLUE));
-        ThermometerPlot p2 = (ThermometerPlot) TestUtils.serialised(p1);
+        ThermometerPlot p2 = TestUtils.serialised(p1);
         assertTrue(p1.equals(p2));
     }
 

--- a/src/test/java/org/jfree/chart/plot/ValueMarkerTest.java
+++ b/src/test/java/org/jfree/chart/plot/ValueMarkerTest.java
@@ -168,7 +168,7 @@ public class ValueMarkerTest implements MarkerChangeListener {
     @Test
     public void testSerialization() {
         ValueMarker m1 = new ValueMarker(25.0);
-        ValueMarker m2 = (ValueMarker) TestUtils.serialised(m1);
+        ValueMarker m2 = TestUtils.serialised(m1);
         assertEquals(m1, m2);
     }
 
@@ -204,7 +204,7 @@ public class ValueMarkerTest implements MarkerChangeListener {
     @Test
     public void test1802195() {
         ValueMarker m1 = new ValueMarker(25.0);
-        ValueMarker m2 = (ValueMarker) TestUtils.serialised(m1);
+        ValueMarker m2 = TestUtils.serialised(m1);
         assertEquals(m1, m2);
         try {
             m2.setValue(-10.0);

--- a/src/test/java/org/jfree/chart/plot/XYPlotTest.java
+++ b/src/test/java/org/jfree/chart/plot/XYPlotTest.java
@@ -706,7 +706,7 @@ public class XYPlotTest {
         NumberAxis rangeAxis = new NumberAxis("Range");
         StandardXYItemRenderer renderer = new StandardXYItemRenderer();
         XYPlot p1 = new XYPlot(data, domainAxis, rangeAxis, renderer);
-        XYPlot p2 = (XYPlot) TestUtils.serialised(p1);
+        XYPlot p2 = TestUtils.serialised(p1);
         assertEquals(p1, p2);
     }
 
@@ -721,7 +721,7 @@ public class XYPlotTest {
         renderer1.setDefaultToolTipGenerator(
                 StandardXYToolTipGenerator.getTimeSeriesInstance());
         XYPlot p1 = new XYPlot(data1, new DateAxis("Date"), null, renderer1);
-        XYPlot p2 = (XYPlot) TestUtils.serialised(p1);
+        XYPlot p2 = TestUtils.serialised(p1);
         assertEquals(p1, p2);
     }
 
@@ -741,7 +741,7 @@ public class XYPlotTest {
         XYSeriesCollection dataset = new XYSeriesCollection();
         JFreeChart chart = ChartFactory.createXYLineChart("Test Chart",
                 "Domain Axis", "Range Axis", dataset);
-        JFreeChart chart2 = (JFreeChart) TestUtils.serialised(chart);
+        JFreeChart chart2 = TestUtils.serialised(chart);
         assertEquals(chart, chart2);
         try {
             chart2.createBufferedImage(300, 200);
@@ -766,7 +766,7 @@ public class XYPlotTest {
         plot.addDomainMarker(new IntervalMarker(2.0, 3.0), Layer.BACKGROUND);
         plot.addRangeMarker(new ValueMarker(4.0), Layer.FOREGROUND);
         plot.addRangeMarker(new IntervalMarker(5.0, 6.0), Layer.BACKGROUND);
-        JFreeChart chart2 = (JFreeChart) TestUtils.serialised(chart);
+        JFreeChart chart2 = TestUtils.serialised(chart);
         assertEquals(chart, chart2);
         try {
             chart2.createBufferedImage(300, 200);
@@ -796,7 +796,7 @@ public class XYPlotTest {
         p1.setDomainAxis(1, domainAxis2);
         p1.setRangeAxis(1, rangeAxis2);
         p1.setRenderer(1, renderer2);
-        XYPlot p2 = (XYPlot) TestUtils.serialised(p1);
+        XYPlot p2 = TestUtils.serialised(p1);
         assertEquals(p1, p2);
 
         // now check that all datasets, renderers and axes are being listened

--- a/src/test/java/org/jfree/chart/plot/dial/AbstractDialLayerTest.java
+++ b/src/test/java/org/jfree/chart/plot/dial/AbstractDialLayerTest.java
@@ -90,7 +90,7 @@ public class AbstractDialLayerTest {
     public void testSerialization() {
         // test a default instance
         DialCap c1 = new DialCap();
-        DialCap c2 = (DialCap) TestUtils.serialised(c1);
+        DialCap c2 = TestUtils.serialised(c1);
         assertEquals(c1, c2);
 
         // check that the listener lists are independent

--- a/src/test/java/org/jfree/chart/plot/dial/ArcDialFrameTest.java
+++ b/src/test/java/org/jfree/chart/plot/dial/ArcDialFrameTest.java
@@ -151,7 +151,7 @@ public class ArcDialFrameTest {
     @Test
     public void testSerialization() {
         ArcDialFrame f1 = new ArcDialFrame();
-        ArcDialFrame f2 = (ArcDialFrame) TestUtils.serialised(f1);
+        ArcDialFrame f2 = TestUtils.serialised(f1);
         assertEquals(f1, f2);
     }
 

--- a/src/test/java/org/jfree/chart/plot/dial/DialBackgroundTest.java
+++ b/src/test/java/org/jfree/chart/plot/dial/DialBackgroundTest.java
@@ -147,7 +147,7 @@ public class DialBackgroundTest {
         b1.setGradientPaintTransformer(new StandardGradientPaintTransformer(
                 GradientPaintTransformType.CENTER_VERTICAL));
 
-        b2 = (DialBackground) TestUtils.serialised(b1);
+        b2 = TestUtils.serialised(b1);
         assertEquals(b1, b2);
     }
 

--- a/src/test/java/org/jfree/chart/plot/dial/DialCapTest.java
+++ b/src/test/java/org/jfree/chart/plot/dial/DialCapTest.java
@@ -161,7 +161,7 @@ public class DialCapTest {
                 3.0f, 4.0f, Color.GRAY));
         c1.setOutlineStroke(new BasicStroke(2.0f));
 
-        c2 = (DialCap) TestUtils.serialised(c1);
+        c2 = TestUtils.serialised(c1);
         assertEquals(c1, c2);
     }
 

--- a/src/test/java/org/jfree/chart/plot/dial/DialPlotTest.java
+++ b/src/test/java/org/jfree/chart/plot/dial/DialPlotTest.java
@@ -161,7 +161,7 @@ public class DialPlotTest implements PlotChangeListener {
     @Test
     public void testSerialization() {
         DialPlot p1 = new DialPlot();
-        DialPlot p2 = (DialPlot) TestUtils.serialised(p1);
+        DialPlot p2 = TestUtils.serialised(p1);
         assertEquals(p1, p2);
     }
 

--- a/src/test/java/org/jfree/chart/plot/dial/DialPointerTest.java
+++ b/src/test/java/org/jfree/chart/plot/dial/DialPointerTest.java
@@ -152,7 +152,7 @@ public class DialPointerTest {
     public void testSerialization() {
         // test a default instance
         DialPointer i1 = new DialPointer.Pin(1);
-        DialPointer i2 = (DialPointer) TestUtils.serialised(i1);
+        DialPointer i2 = TestUtils.serialised(i1);
         assertEquals(i1, i2);
     }
 
@@ -162,7 +162,7 @@ public class DialPointerTest {
     @Test
     public void testSerialization2() {
         DialPointer i1 = new DialPointer.Pointer(1);
-        DialPointer i2 = (DialPointer) TestUtils.serialised(i1);
+        DialPointer i2 = TestUtils.serialised(i1);
         assertEquals(i1, i2);
     }
 }

--- a/src/test/java/org/jfree/chart/plot/dial/DialTextAnnotationTest.java
+++ b/src/test/java/org/jfree/chart/plot/dial/DialTextAnnotationTest.java
@@ -139,7 +139,7 @@ public class DialTextAnnotationTest {
     public void testSerialization() {
         // test a default instance
         DialTextAnnotation a1 = new DialTextAnnotation("A1");
-        DialTextAnnotation a2 = (DialTextAnnotation) TestUtils.serialised(a1);
+        DialTextAnnotation a2 = TestUtils.serialised(a1);
         assertEquals(a1, a2);
 
         // test a custom instance
@@ -147,7 +147,7 @@ public class DialTextAnnotationTest {
         a1.setPaint(new GradientPaint(1.0f, 2.0f, Color.RED, 3.0f, 4.0f,
                 Color.BLUE));
 
-        a2 = (DialTextAnnotation) TestUtils.serialised(a1);
+        a2 = TestUtils.serialised(a1);
         assertEquals(a1, a2);
     }
 

--- a/src/test/java/org/jfree/chart/plot/dial/DialValueIndicatorTest.java
+++ b/src/test/java/org/jfree/chart/plot/dial/DialValueIndicatorTest.java
@@ -198,8 +198,7 @@ public class DialValueIndicatorTest {
     @Test
     public void testSerialization() {
         DialValueIndicator i1 = new DialValueIndicator(0);
-        DialValueIndicator i2 = (DialValueIndicator) 
-                TestUtils.serialised(i1);
+        DialValueIndicator i2 = TestUtils.serialised(i1);
         assertEquals(i1, i2);
     }
 

--- a/src/test/java/org/jfree/chart/plot/dial/StandardDialFrameTest.java
+++ b/src/test/java/org/jfree/chart/plot/dial/StandardDialFrameTest.java
@@ -133,7 +133,7 @@ public class StandardDialFrameTest {
     @Test
     public void testSerialization() {
         StandardDialFrame f1 = new StandardDialFrame();
-        StandardDialFrame f2 = (StandardDialFrame) TestUtils.serialised(f1);
+        StandardDialFrame f2 = TestUtils.serialised(f1);
         assertEquals(f1, f2);
     }
 

--- a/src/test/java/org/jfree/chart/plot/dial/StandardDialRangeTest.java
+++ b/src/test/java/org/jfree/chart/plot/dial/StandardDialRangeTest.java
@@ -124,7 +124,7 @@ public class StandardDialRangeTest {
     @Test
     public void testSerialization() {
         StandardDialRange r1 = new StandardDialRange();
-        StandardDialRange r2 = (StandardDialRange) TestUtils.serialised(r1);
+        StandardDialRange r2 = TestUtils.serialised(r1);
         assertEquals(r1, r2);
     }
 

--- a/src/test/java/org/jfree/chart/plot/dial/StandardDialScaleTest.java
+++ b/src/test/java/org/jfree/chart/plot/dial/StandardDialScaleTest.java
@@ -212,7 +212,7 @@ public class StandardDialScaleTest {
     public void testSerialization() {
         // try a default instance
         StandardDialScale s1 = new StandardDialScale();
-        StandardDialScale s2 = (StandardDialScale) TestUtils.serialised(s1);
+        StandardDialScale s2 = TestUtils.serialised(s1);
         assertEquals(s1, s2);
 
         // try a customised instance
@@ -222,7 +222,7 @@ public class StandardDialScaleTest {
                 4.0f, Color.WHITE));
         s1.setMajorTickStroke(new BasicStroke(2.0f));
 
-        s2 = (StandardDialScale) TestUtils.serialised(s1);
+        s2 = TestUtils.serialised(s1);
         assertEquals(s1, s2);
     }
 

--- a/src/test/java/org/jfree/chart/renderer/AbstractRendererTest.java
+++ b/src/test/java/org/jfree/chart/renderer/AbstractRendererTest.java
@@ -684,7 +684,7 @@ public class AbstractRendererTest {
         r1.setDefaultLegendTextPaint(new GradientPaint(1.0f, 2.0f, Color.RED,
                 3.0f, 4.0f, Color.GREEN));
         r1.setDefaultLegendShape(new Line2D.Double(1.0, 2.0, 3.0, 4.0));
-        BarRenderer r2 = (BarRenderer) TestUtils.serialised(r1);
+        BarRenderer r2 = TestUtils.serialised(r1);
         assertEquals(r1, r2);
         try {
             r2.notifyListeners(new RendererChangeEvent(r2));

--- a/src/test/java/org/jfree/chart/renderer/AreaRendererEndTypeTest.java
+++ b/src/test/java/org/jfree/chart/renderer/AreaRendererEndTypeTest.java
@@ -64,7 +64,7 @@ public class AreaRendererEndTypeTest {
     @Test
     public void testSerialization() {
         AreaRendererEndType t1 = AreaRendererEndType.TAPER;
-        AreaRendererEndType t2 = (AreaRendererEndType) TestUtils.serialised(t1);
+        AreaRendererEndType t2 = TestUtils.serialised(t1);
         assertEquals(t1, t2);
         boolean same = t1 == t2;
         assertEquals(true, same);

--- a/src/test/java/org/jfree/chart/renderer/DefaultPolarItemRendererTest.java
+++ b/src/test/java/org/jfree/chart/renderer/DefaultPolarItemRendererTest.java
@@ -101,8 +101,7 @@ public class DefaultPolarItemRendererTest {
     @Test
     public void testSerialization() {
         DefaultPolarItemRenderer r1 = new DefaultPolarItemRenderer();
-        DefaultPolarItemRenderer r2 = (DefaultPolarItemRenderer) 
-                TestUtils.serialised(r1);
+        DefaultPolarItemRenderer r2 = TestUtils.serialised(r1);
         assertEquals(r1, r2);
     }
 

--- a/src/test/java/org/jfree/chart/renderer/GrayPaintScaleTest.java
+++ b/src/test/java/org/jfree/chart/renderer/GrayPaintScaleTest.java
@@ -129,7 +129,7 @@ public class GrayPaintScaleTest {
     @Test
     public void testSerialization() {
         GrayPaintScale g1 = new GrayPaintScale();
-        GrayPaintScale g2 = (GrayPaintScale) TestUtils.serialised(g1);
+        GrayPaintScale g2 = TestUtils.serialised(g1);
         assertEquals(g1, g2);
     }
 

--- a/src/test/java/org/jfree/chart/renderer/LookupPaintScaleTest.java
+++ b/src/test/java/org/jfree/chart/renderer/LookupPaintScaleTest.java
@@ -108,14 +108,14 @@ public class LookupPaintScaleTest {
     @Test
     public void testSerialization() {
         LookupPaintScale g1 = new LookupPaintScale();
-        LookupPaintScale g2 = (LookupPaintScale) TestUtils.serialised(g1);
+        LookupPaintScale g2 = TestUtils.serialised(g1);
         assertEquals(g1, g2);
 
         g1 = new LookupPaintScale(1.0, 2.0, new GradientPaint(1.0f, 2.0f,
                 Color.RED, 3.0f, 4.0f, Color.YELLOW));
         g1.add(1.5, new GradientPaint(1.1f, 2.2f, Color.RED, 3.3f, 4.4f,
                 Color.BLUE));
-        g2 = (LookupPaintScale) TestUtils.serialised(g1);
+        g2 = TestUtils.serialised(g1);
         assertEquals(g1, g2);
     }
 

--- a/src/test/java/org/jfree/chart/renderer/category/AreaRendererTest.java
+++ b/src/test/java/org/jfree/chart/renderer/category/AreaRendererTest.java
@@ -111,7 +111,7 @@ public class AreaRendererTest {
     @Test
     public void testSerialization() {
         AreaRenderer r1 = new AreaRenderer();
-        AreaRenderer r2 = (AreaRenderer) TestUtils.serialised(r1);
+        AreaRenderer r2 = TestUtils.serialised(r1);
         assertEquals(r1, r2);
     }
 

--- a/src/test/java/org/jfree/chart/renderer/category/BarRendererTest.java
+++ b/src/test/java/org/jfree/chart/renderer/category/BarRendererTest.java
@@ -204,7 +204,7 @@ public class BarRendererTest {
     @Test
     public void testSerialization() {
         BarRenderer r1 = new BarRenderer();
-        BarRenderer r2 = (BarRenderer) TestUtils.serialised(r1);
+        BarRenderer r2 = TestUtils.serialised(r1);
         assertEquals(r1, r2);
     }
 

--- a/src/test/java/org/jfree/chart/renderer/category/BoxAndWhiskerRendererTest.java
+++ b/src/test/java/org/jfree/chart/renderer/category/BoxAndWhiskerRendererTest.java
@@ -164,8 +164,7 @@ public class BoxAndWhiskerRendererTest {
     @Test
     public void testSerialization() {
         BoxAndWhiskerRenderer r1 = new BoxAndWhiskerRenderer();
-        BoxAndWhiskerRenderer r2 = (BoxAndWhiskerRenderer) 
-                TestUtils.serialised(r1);
+        BoxAndWhiskerRenderer r2 = TestUtils.serialised(r1);
         assertEquals(r1, r2);
     }
 

--- a/src/test/java/org/jfree/chart/renderer/category/CategoryStepRendererTest.java
+++ b/src/test/java/org/jfree/chart/renderer/category/CategoryStepRendererTest.java
@@ -97,8 +97,7 @@ public class CategoryStepRendererTest {
     @Test
     public void testSerialization() {
         CategoryStepRenderer r1 = new CategoryStepRenderer();
-        CategoryStepRenderer r2 = (CategoryStepRenderer) 
-                TestUtils.serialised(r1);
+        CategoryStepRenderer r2 = TestUtils.serialised(r1);
         assertEquals(r1, r2);
     }
 

--- a/src/test/java/org/jfree/chart/renderer/category/DefaultCategoryItemRendererTest.java
+++ b/src/test/java/org/jfree/chart/renderer/category/DefaultCategoryItemRendererTest.java
@@ -100,8 +100,7 @@ public class DefaultCategoryItemRendererTest {
     @Test
     public void testSerialization() {
         DefaultCategoryItemRenderer r1 = new DefaultCategoryItemRenderer();
-        DefaultCategoryItemRenderer r2 = (DefaultCategoryItemRenderer) 
-                TestUtils.serialised(r1);
+        DefaultCategoryItemRenderer r2 = TestUtils.serialised(r1);
         assertEquals(r1, r2);
     }
 

--- a/src/test/java/org/jfree/chart/renderer/category/GanttRendererTest.java
+++ b/src/test/java/org/jfree/chart/renderer/category/GanttRendererTest.java
@@ -127,7 +127,7 @@ public class GanttRendererTest {
                 4.0f, Color.BLUE));
         r1.setIncompletePaint(new GradientPaint(4.0f, 3.0f, Color.RED, 2.0f,
                 1.0f, Color.BLUE));
-        GanttRenderer r2 = (GanttRenderer) TestUtils.serialised(r1);
+        GanttRenderer r2 = TestUtils.serialised(r1);
         assertEquals(r1, r2);
     }
 

--- a/src/test/java/org/jfree/chart/renderer/category/GradientBarPainterTest.java
+++ b/src/test/java/org/jfree/chart/renderer/category/GradientBarPainterTest.java
@@ -105,7 +105,7 @@ public class GradientBarPainterTest {
     @Test
     public void testSerialization() {
         GradientBarPainter p1 = new GradientBarPainter(0.1, 0.2, 0.3);
-        GradientBarPainter p2 = (GradientBarPainter) TestUtils.serialised(p1);
+        GradientBarPainter p2 = TestUtils.serialised(p1);
         assertEquals(p1, p2);
     }
 

--- a/src/test/java/org/jfree/chart/renderer/category/GroupedStackedBarRendererTest.java
+++ b/src/test/java/org/jfree/chart/renderer/category/GroupedStackedBarRendererTest.java
@@ -106,8 +106,7 @@ public class GroupedStackedBarRendererTest {
     @Test
     public void testSerialization() {
         GroupedStackedBarRenderer r1 = new GroupedStackedBarRenderer();
-        GroupedStackedBarRenderer r2 = (GroupedStackedBarRenderer) 
-                TestUtils.serialised(r1);
+        GroupedStackedBarRenderer r2 = TestUtils.serialised(r1);
         assertEquals(r1, r2);
     }
 

--- a/src/test/java/org/jfree/chart/renderer/category/IntervalBarRendererTest.java
+++ b/src/test/java/org/jfree/chart/renderer/category/IntervalBarRendererTest.java
@@ -111,7 +111,7 @@ public class IntervalBarRendererTest {
     @Test
     public void testSerialization() {
         IntervalBarRenderer r1 = new IntervalBarRenderer();
-        IntervalBarRenderer r2 = (IntervalBarRenderer) TestUtils.serialised(r1);
+        IntervalBarRenderer r2 = TestUtils.serialised(r1);
         assertEquals(r1, r2);
     }
 

--- a/src/test/java/org/jfree/chart/renderer/category/LayeredBarRendererTest.java
+++ b/src/test/java/org/jfree/chart/renderer/category/LayeredBarRendererTest.java
@@ -104,7 +104,7 @@ public class LayeredBarRendererTest {
     @Test
     public void testSerialization() {
         LayeredBarRenderer r1 = new LayeredBarRenderer();
-        LayeredBarRenderer r2 = (LayeredBarRenderer) TestUtils.serialised(r1);
+        LayeredBarRenderer r2 = TestUtils.serialised(r1);
         assertEquals(r1, r2);
     }
 

--- a/src/test/java/org/jfree/chart/renderer/category/LevelRendererTest.java
+++ b/src/test/java/org/jfree/chart/renderer/category/LevelRendererTest.java
@@ -146,7 +146,7 @@ public class LevelRendererTest {
     @Test
     public void testSerialization() {
         LevelRenderer r1 = new LevelRenderer();
-        LevelRenderer r2 = (LevelRenderer) TestUtils.serialised(r1);
+        LevelRenderer r2 = TestUtils.serialised(r1);
         assertEquals(r1, r2);
     }
 

--- a/src/test/java/org/jfree/chart/renderer/category/LineAndShapeRendererTest.java
+++ b/src/test/java/org/jfree/chart/renderer/category/LineAndShapeRendererTest.java
@@ -231,8 +231,7 @@ public class LineAndShapeRendererTest {
     @Test
     public void testSerialization() {
         LineAndShapeRenderer r1 = new LineAndShapeRenderer();
-        LineAndShapeRenderer r2 = (LineAndShapeRenderer) 
-                TestUtils.serialised(r1);
+        LineAndShapeRenderer r2 = TestUtils.serialised(r1);
         assertEquals(r1, r2);
     }
 

--- a/src/test/java/org/jfree/chart/renderer/category/MinMaxCategoryRendererTest.java
+++ b/src/test/java/org/jfree/chart/renderer/category/MinMaxCategoryRendererTest.java
@@ -126,8 +126,7 @@ public class MinMaxCategoryRendererTest {
     @Test
     public void testSerialization() {
         MinMaxCategoryRenderer r1 = new MinMaxCategoryRenderer();
-        MinMaxCategoryRenderer r2 = (MinMaxCategoryRenderer) 
-                TestUtils.serialised(r1);
+        MinMaxCategoryRenderer r2 = TestUtils.serialised(r1);
         assertEquals(r1, r2);
     }
 

--- a/src/test/java/org/jfree/chart/renderer/category/ScatterRendererTest.java
+++ b/src/test/java/org/jfree/chart/renderer/category/ScatterRendererTest.java
@@ -178,7 +178,7 @@ public class ScatterRendererTest {
     @Test
     public void testSerialization() {
         ScatterRenderer r1 = new ScatterRenderer();
-        ScatterRenderer r2 = (ScatterRenderer) TestUtils.serialised(r1);
+        ScatterRenderer r2 = TestUtils.serialised(r1);
         assertEquals(r1, r2);
     }
 

--- a/src/test/java/org/jfree/chart/renderer/category/StackedAreaRendererTest.java
+++ b/src/test/java/org/jfree/chart/renderer/category/StackedAreaRendererTest.java
@@ -136,8 +136,7 @@ public class StackedAreaRendererTest {
     @Test
     public void testSerialization() {
         StackedAreaRenderer r1 = new StackedAreaRenderer();
-        StackedAreaRenderer r2 = (StackedAreaRenderer) 
-                TestUtils.serialised(r1);
+        StackedAreaRenderer r2 = TestUtils.serialised(r1);
         assertEquals(r1, r2);
     }
 

--- a/src/test/java/org/jfree/chart/renderer/category/StackedBarRendererTest.java
+++ b/src/test/java/org/jfree/chart/renderer/category/StackedBarRendererTest.java
@@ -109,8 +109,7 @@ public class StackedBarRendererTest {
     @Test
     public void testSerialization() {
         StackedBarRenderer r1 = new StackedBarRenderer();
-        StackedBarRenderer r2 = (StackedBarRenderer) 
-                TestUtils.serialised(r1);
+        StackedBarRenderer r2 = TestUtils.serialised(r1);
         assertEquals(r1, r2);
     }
 

--- a/src/test/java/org/jfree/chart/renderer/category/StandardBarPainterTest.java
+++ b/src/test/java/org/jfree/chart/renderer/category/StandardBarPainterTest.java
@@ -90,8 +90,7 @@ public class StandardBarPainterTest {
     @Test
     public void testSerialization() {
         StandardBarPainter p1 = new StandardBarPainter();
-        StandardBarPainter p2 = (StandardBarPainter) 
-                TestUtils.serialised(p1);
+        StandardBarPainter p2 = TestUtils.serialised(p1);
         assertEquals(p1, p2);
     }
 

--- a/src/test/java/org/jfree/chart/renderer/category/StatisticalBarRendererTest.java
+++ b/src/test/java/org/jfree/chart/renderer/category/StatisticalBarRendererTest.java
@@ -122,8 +122,7 @@ public class StatisticalBarRendererTest {
     @Test
     public void testSerialization() {
         StatisticalBarRenderer r1 = new StatisticalBarRenderer();
-        StatisticalBarRenderer r2 = (StatisticalBarRenderer) 
-                TestUtils.serialised(r1);
+        StatisticalBarRenderer r2 = TestUtils.serialised(r1);
         assertEquals(r1, r2);
     }
 

--- a/src/test/java/org/jfree/chart/renderer/category/StatisticalLineAndShapeRendererTest.java
+++ b/src/test/java/org/jfree/chart/renderer/category/StatisticalLineAndShapeRendererTest.java
@@ -123,8 +123,7 @@ public class StatisticalLineAndShapeRendererTest {
     public void testSerialization() {
         StatisticalLineAndShapeRenderer r1
                 = new StatisticalLineAndShapeRenderer();
-        StatisticalLineAndShapeRenderer r2 = (StatisticalLineAndShapeRenderer) 
-                TestUtils.serialised(r1);
+        StatisticalLineAndShapeRenderer r2 = TestUtils.serialised(r1);
         assertEquals(r1, r2);
     }
 

--- a/src/test/java/org/jfree/chart/renderer/xy/CandlestickRendererTest.java
+++ b/src/test/java/org/jfree/chart/renderer/xy/CandlestickRendererTest.java
@@ -189,8 +189,7 @@ public class CandlestickRendererTest {
     @Test
     public void testSerialization() {
         CandlestickRenderer r1 = new CandlestickRenderer();
-        CandlestickRenderer r2 = (CandlestickRenderer) 
-                TestUtils.serialised(r1);
+        CandlestickRenderer r2 = TestUtils.serialised(r1);
         assertEquals(r1, r2);
     }
 

--- a/src/test/java/org/jfree/chart/renderer/xy/ClusteredXYBarRendererTest.java
+++ b/src/test/java/org/jfree/chart/renderer/xy/ClusteredXYBarRendererTest.java
@@ -114,8 +114,7 @@ public class ClusteredXYBarRendererTest {
     @Test
     public void testSerialization() {
         ClusteredXYBarRenderer r1 = new ClusteredXYBarRenderer();
-        ClusteredXYBarRenderer r2 = (ClusteredXYBarRenderer) 
-                TestUtils.serialised(r1);
+        ClusteredXYBarRenderer r2 = TestUtils.serialised(r1);
         assertEquals(r1, r2);
     }
 

--- a/src/test/java/org/jfree/chart/renderer/xy/DeviationRendererTest.java
+++ b/src/test/java/org/jfree/chart/renderer/xy/DeviationRendererTest.java
@@ -107,7 +107,7 @@ public class DeviationRendererTest {
     @Test
     public void testSerialization() {
         DeviationRenderer r1 = new DeviationRenderer();
-        DeviationRenderer r2 = (DeviationRenderer) TestUtils.serialised(r1);
+        DeviationRenderer r2 = TestUtils.serialised(r1);
         assertEquals(r1, r2);
     }
 

--- a/src/test/java/org/jfree/chart/renderer/xy/DeviationStepRendererTest.java
+++ b/src/test/java/org/jfree/chart/renderer/xy/DeviationStepRendererTest.java
@@ -105,7 +105,7 @@ public class DeviationStepRendererTest {
     @Test
     public void testSerialization() {
         DeviationStepRenderer r1 = new DeviationStepRenderer();
-        DeviationStepRenderer r2 = (DeviationStepRenderer) TestUtils.serialised(r1);
+        DeviationStepRenderer r2 = TestUtils.serialised(r1);
         assertEquals(r1, r2);
     }
 

--- a/src/test/java/org/jfree/chart/renderer/xy/GradientXYBarPainterTest.java
+++ b/src/test/java/org/jfree/chart/renderer/xy/GradientXYBarPainterTest.java
@@ -105,8 +105,7 @@ public class GradientXYBarPainterTest {
     @Test
     public void testSerialization() {
         GradientXYBarPainter p1 = new GradientXYBarPainter(0.1, 0.2, 0.3);
-        GradientXYBarPainter p2 = (GradientXYBarPainter) 
-                TestUtils.serialised(p1);
+        GradientXYBarPainter p2 = TestUtils.serialised(p1);
         assertEquals(p1, p2);
     }
 

--- a/src/test/java/org/jfree/chart/renderer/xy/HighLowRendererTest.java
+++ b/src/test/java/org/jfree/chart/renderer/xy/HighLowRendererTest.java
@@ -140,7 +140,7 @@ public class HighLowRendererTest {
     public void testSerialization() {
         HighLowRenderer r1 = new HighLowRenderer();
         r1.setCloseTickPaint(Color.GREEN);
-        HighLowRenderer r2 = (HighLowRenderer) TestUtils.serialised(r1);
+        HighLowRenderer r2 = TestUtils.serialised(r1);
         assertEquals(r1, r2);
     }
 

--- a/src/test/java/org/jfree/chart/renderer/xy/StackedXYAreaRenderer2Test.java
+++ b/src/test/java/org/jfree/chart/renderer/xy/StackedXYAreaRenderer2Test.java
@@ -144,8 +144,7 @@ public class StackedXYAreaRenderer2Test {
     @Test
     public void testSerialization() {
         StackedXYAreaRenderer2 r1 = new StackedXYAreaRenderer2();
-        StackedXYAreaRenderer2 r2 = (StackedXYAreaRenderer2) 
-                TestUtils.serialised(r1);
+        StackedXYAreaRenderer2 r2 = TestUtils.serialised(r1);
         assertEquals(r1, r2);
     }
 

--- a/src/test/java/org/jfree/chart/renderer/xy/StackedXYAreaRendererTest.java
+++ b/src/test/java/org/jfree/chart/renderer/xy/StackedXYAreaRendererTest.java
@@ -130,8 +130,7 @@ public class StackedXYAreaRendererTest {
         StackedXYAreaRenderer r1 = new StackedXYAreaRenderer();
         r1.setShapePaint(Color.RED);
         r1.setShapeStroke(new BasicStroke(1.23f));
-        StackedXYAreaRenderer r2 = (StackedXYAreaRenderer) 
-                TestUtils.serialised(r1);
+        StackedXYAreaRenderer r2 = TestUtils.serialised(r1);
         assertEquals(r1, r2);
     }
 

--- a/src/test/java/org/jfree/chart/renderer/xy/StackedXYBarRendererTest.java
+++ b/src/test/java/org/jfree/chart/renderer/xy/StackedXYBarRendererTest.java
@@ -122,8 +122,7 @@ public class StackedXYBarRendererTest {
         StackedXYBarRenderer r1 = new StackedXYBarRenderer();
         r1.setSeriesPaint(0, new GradientPaint(1.0f, 2.0f, Color.RED, 3.0f,
                 4.0f, Color.YELLOW));
-        StackedXYBarRenderer r2 = (StackedXYBarRenderer) 
-                TestUtils.serialised(r1);
+        StackedXYBarRenderer r2 = TestUtils.serialised(r1);
         assertEquals(r1, r2);
     }
 

--- a/src/test/java/org/jfree/chart/renderer/xy/StandardXYBarPainterTest.java
+++ b/src/test/java/org/jfree/chart/renderer/xy/StandardXYBarPainterTest.java
@@ -90,8 +90,7 @@ public class StandardXYBarPainterTest {
     @Test
     public void testSerialization() {
         StandardXYBarPainter p1 = new StandardXYBarPainter();
-        StandardXYBarPainter p2 = (StandardXYBarPainter) 
-                TestUtils.serialised(p1);
+        StandardXYBarPainter p2 = TestUtils.serialised(p1);
         assertEquals(p1, p2);
     }
 

--- a/src/test/java/org/jfree/chart/renderer/xy/StandardXYItemRendererTest.java
+++ b/src/test/java/org/jfree/chart/renderer/xy/StandardXYItemRendererTest.java
@@ -179,8 +179,7 @@ public class StandardXYItemRendererTest {
     @Test
     public void testSerialization() {
         StandardXYItemRenderer r1 = new StandardXYItemRenderer();
-        StandardXYItemRenderer r2 = (StandardXYItemRenderer) 
-                TestUtils.serialised(r1);
+        StandardXYItemRenderer r2 = TestUtils.serialised(r1);
         assertEquals(r1, r2);
     }
 

--- a/src/test/java/org/jfree/chart/renderer/xy/VectorRendererTest.java
+++ b/src/test/java/org/jfree/chart/renderer/xy/VectorRendererTest.java
@@ -112,7 +112,7 @@ public class VectorRendererTest {
     @Test
     public void testSerialization() {
         VectorRenderer r1 = new VectorRenderer();
-        VectorRenderer r2 = (VectorRenderer) TestUtils.serialised(r1);
+        VectorRenderer r2 = TestUtils.serialised(r1);
         assertEquals(r1, r2);
     }
 

--- a/src/test/java/org/jfree/chart/renderer/xy/WindItemRendererTest.java
+++ b/src/test/java/org/jfree/chart/renderer/xy/WindItemRendererTest.java
@@ -99,7 +99,7 @@ public class WindItemRendererTest {
     @Test
     public void testSerialization() {
         WindItemRenderer r1 = new WindItemRenderer();
-        WindItemRenderer r2 = (WindItemRenderer) TestUtils.serialised(r1);
+        WindItemRenderer r2 = TestUtils.serialised(r1);
         assertEquals(r1, r2);
     }
 

--- a/src/test/java/org/jfree/chart/renderer/xy/XYAreaRenderer2Test.java
+++ b/src/test/java/org/jfree/chart/renderer/xy/XYAreaRenderer2Test.java
@@ -125,7 +125,7 @@ public class XYAreaRenderer2Test {
     @Test
     public void testSerialization() {
         XYAreaRenderer2 r1 = new XYAreaRenderer2();
-        XYAreaRenderer2 r2 = (XYAreaRenderer2) TestUtils.serialised(r1);
+        XYAreaRenderer2 r2 = TestUtils.serialised(r1);
         assertEquals(r1, r2);
     }
 

--- a/src/test/java/org/jfree/chart/renderer/xy/XYAreaRendererTest.java
+++ b/src/test/java/org/jfree/chart/renderer/xy/XYAreaRendererTest.java
@@ -169,7 +169,7 @@ public class XYAreaRendererTest {
     @Test
     public void testSerialization() {
         XYAreaRenderer r1 = new XYAreaRenderer();
-        XYAreaRenderer r2 = (XYAreaRenderer) TestUtils.serialised(r1);
+        XYAreaRenderer r2 = TestUtils.serialised(r1);
         assertEquals(r1, r2);
     }
 

--- a/src/test/java/org/jfree/chart/renderer/xy/XYBarRendererTest.java
+++ b/src/test/java/org/jfree/chart/renderer/xy/XYBarRendererTest.java
@@ -203,7 +203,7 @@ public class XYBarRendererTest {
     @Test
     public void testSerialization() {
         XYBarRenderer r1 = new XYBarRenderer();
-        XYBarRenderer r2 = (XYBarRenderer) TestUtils.serialised(r1);
+        XYBarRenderer r2 = TestUtils.serialised(r1);
         assertEquals(r1, r2);
     }
 
@@ -214,7 +214,7 @@ public class XYBarRendererTest {
     public void testSerialization2() {
         XYBarRenderer r1 = new XYBarRenderer();
         r1.setPositiveItemLabelPositionFallback(new ItemLabelPosition());
-        XYBarRenderer r2 = (XYBarRenderer) TestUtils.serialised(r1);
+        XYBarRenderer r2 = TestUtils.serialised(r1);
         assertEquals(r1, r2);
     }
 

--- a/src/test/java/org/jfree/chart/renderer/xy/XYBlockRendererTest.java
+++ b/src/test/java/org/jfree/chart/renderer/xy/XYBlockRendererTest.java
@@ -142,7 +142,7 @@ public class XYBlockRendererTest {
     @Test
     public void testSerialization() {
         XYBlockRenderer r1 = new XYBlockRenderer();
-        XYBlockRenderer r2 = (XYBlockRenderer) TestUtils.serialised(r1);
+        XYBlockRenderer r2 = TestUtils.serialised(r1);
         assertEquals(r1, r2);
     }
 

--- a/src/test/java/org/jfree/chart/renderer/xy/XYBoxAndWhiskerRendererTest.java
+++ b/src/test/java/org/jfree/chart/renderer/xy/XYBoxAndWhiskerRendererTest.java
@@ -141,8 +141,7 @@ public class XYBoxAndWhiskerRendererTest {
     @Test
     public void testSerialization() {
         XYBoxAndWhiskerRenderer r1 = new XYBoxAndWhiskerRenderer();
-        XYBoxAndWhiskerRenderer r2 = (XYBoxAndWhiskerRenderer) 
-                TestUtils.serialised(r1);
+        XYBoxAndWhiskerRenderer r2 = TestUtils.serialised(r1);
         assertEquals(r1, r2);
     }
 

--- a/src/test/java/org/jfree/chart/renderer/xy/XYBubbleRendererTest.java
+++ b/src/test/java/org/jfree/chart/renderer/xy/XYBubbleRendererTest.java
@@ -109,7 +109,7 @@ public class XYBubbleRendererTest {
     @Test
     public void testSerialization() {
         XYBubbleRenderer r1 = new XYBubbleRenderer();
-        XYBubbleRenderer r2 = (XYBubbleRenderer) TestUtils.serialised(r1);
+        XYBubbleRenderer r2 = TestUtils.serialised(r1);
         assertEquals(r1, r2);
     }
 

--- a/src/test/java/org/jfree/chart/renderer/xy/XYDifferenceRendererTest.java
+++ b/src/test/java/org/jfree/chart/renderer/xy/XYDifferenceRendererTest.java
@@ -162,8 +162,7 @@ public class XYDifferenceRendererTest {
     public void testSerialization() {
         XYDifferenceRenderer r1 = new XYDifferenceRenderer(Color.RED,
                 Color.BLUE, false);
-        XYDifferenceRenderer r2 = (XYDifferenceRenderer) 
-                TestUtils.serialised(r1);
+        XYDifferenceRenderer r2 = TestUtils.serialised(r1);
         assertEquals(r1, r2);
     }
 

--- a/src/test/java/org/jfree/chart/renderer/xy/XYDotRendererTest.java
+++ b/src/test/java/org/jfree/chart/renderer/xy/XYDotRendererTest.java
@@ -129,7 +129,7 @@ public class XYDotRendererTest {
     @Test
     public void testSerialization() {
         XYDotRenderer r1 = new XYDotRenderer();
-        XYDotRenderer r2 = (XYDotRenderer) TestUtils.serialised(r1);
+        XYDotRenderer r2 = TestUtils.serialised(r1);
         assertEquals(r1, r2);
     }
 

--- a/src/test/java/org/jfree/chart/renderer/xy/XYErrorRendererTest.java
+++ b/src/test/java/org/jfree/chart/renderer/xy/XYErrorRendererTest.java
@@ -155,7 +155,7 @@ public class XYErrorRendererTest {
         XYErrorRenderer r1 = new XYErrorRenderer();
         r1.setErrorPaint(new GradientPaint(1.0f, 2.0f, Color.RED, 3.0f, 4.0f,
                 Color.WHITE));
-        XYErrorRenderer r2 = (XYErrorRenderer) TestUtils.serialised(r1);
+        XYErrorRenderer r2 = TestUtils.serialised(r1);
         assertEquals(r1, r2);
     }
 
@@ -166,7 +166,7 @@ public class XYErrorRendererTest {
     public void testSerialization2() {
         XYErrorRenderer r1 = new XYErrorRenderer();
         r1.setErrorStroke(new BasicStroke(1.5f));
-        XYErrorRenderer r2 = (XYErrorRenderer) TestUtils.serialised(r1);
+        XYErrorRenderer r2 = TestUtils.serialised(r1);
         assertEquals(r1, r2);
     }
 

--- a/src/test/java/org/jfree/chart/renderer/xy/XYLineAndShapeRendererTest.java
+++ b/src/test/java/org/jfree/chart/renderer/xy/XYLineAndShapeRendererTest.java
@@ -206,8 +206,7 @@ public class XYLineAndShapeRendererTest {
     @Test
     public void testSerialization() {
         XYLineAndShapeRenderer r1 = new XYLineAndShapeRenderer();
-        XYLineAndShapeRenderer r2 = (XYLineAndShapeRenderer) 
-                TestUtils.serialised(r1);
+        XYLineAndShapeRenderer r2 = TestUtils.serialised(r1);
         assertEquals(r1, r2);
     }
 

--- a/src/test/java/org/jfree/chart/renderer/xy/XYShapeRendererTest.java
+++ b/src/test/java/org/jfree/chart/renderer/xy/XYShapeRendererTest.java
@@ -118,7 +118,7 @@ public class XYShapeRendererTest {
     @Test
     public void testSerialization() {
         XYShapeRenderer r1 = new XYShapeRenderer();
-        XYShapeRenderer r2 = (XYShapeRenderer) TestUtils.serialised(r1);
+        XYShapeRenderer r2 = TestUtils.serialised(r1);
         assertEquals(r1, r2);
     }
 

--- a/src/test/java/org/jfree/chart/renderer/xy/XYSplineRendererTest.java
+++ b/src/test/java/org/jfree/chart/renderer/xy/XYSplineRendererTest.java
@@ -128,7 +128,7 @@ public class XYSplineRendererTest {
     @Test
     public void testSerialization() {
         XYSplineRenderer r1 = new XYSplineRenderer();
-        XYSplineRenderer r2 = (XYSplineRenderer) TestUtils.serialised(r1);
+        XYSplineRenderer r2 = TestUtils.serialised(r1);
         assertEquals(r1, r2);
     }
 

--- a/src/test/java/org/jfree/chart/renderer/xy/XYStepAreaRendererTest.java
+++ b/src/test/java/org/jfree/chart/renderer/xy/XYStepAreaRendererTest.java
@@ -136,8 +136,7 @@ public class XYStepAreaRendererTest {
     @Test
     public void testSerialization() {
         XYStepAreaRenderer r1 = new XYStepAreaRenderer();
-        XYStepAreaRenderer r2 = (XYStepAreaRenderer) 
-                TestUtils.serialised(r1);
+        XYStepAreaRenderer r2 = TestUtils.serialised(r1);
         assertEquals(r1, r2);
     }
 

--- a/src/test/java/org/jfree/chart/renderer/xy/XYStepRendererTest.java
+++ b/src/test/java/org/jfree/chart/renderer/xy/XYStepRendererTest.java
@@ -119,7 +119,7 @@ public class XYStepRendererTest {
     public void testSerialization() {
         XYStepRenderer r1 = new XYStepRenderer();
         r1.setStepPoint(0.123);
-        XYStepRenderer r2 = (XYStepRenderer) TestUtils.serialised(r1);
+        XYStepRenderer r2 = TestUtils.serialised(r1);
         assertEquals(r1, r2);
     }
 

--- a/src/test/java/org/jfree/chart/renderer/xy/YIntervalRendererTest.java
+++ b/src/test/java/org/jfree/chart/renderer/xy/YIntervalRendererTest.java
@@ -202,7 +202,7 @@ public class YIntervalRendererTest {
     @Test
     public void testSerialization() {
         YIntervalRenderer r1 = new YIntervalRenderer();
-        YIntervalRenderer r2 = (YIntervalRenderer) TestUtils.serialised(r1);
+        YIntervalRenderer r2 = TestUtils.serialised(r1);
         assertEquals(r1, r2);
     }
 

--- a/src/test/java/org/jfree/chart/title/CompositeTitleTest.java
+++ b/src/test/java/org/jfree/chart/title/CompositeTitleTest.java
@@ -44,6 +44,9 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.awt.Color;
 import java.awt.GradientPaint;
+import java.awt.geom.Rectangle2D;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 
 import org.jfree.chart.TestUtils;
 
@@ -56,6 +59,18 @@ import org.junit.jupiter.api.Test;
  * Tests for the {@link CompositeTitle} class.
  */
 public class CompositeTitleTest {
+
+    @Test
+    public void testEqualsHashCode() {
+        EqualsVerifier.forClass(CompositeTitle.class)
+                .suppress(Warning.STRICT_INHERITANCE)
+                .suppress(Warning.NONFINAL_FIELDS)
+                .withRedefinedSuperclass()
+                .withPrefabValues(Rectangle2D.class,
+                                  TestUtils.createR2D(true),
+                                  TestUtils.createR2D(false))
+                .verify();
+    }
 
     /**
      * Some checks for the constructor.

--- a/src/test/java/org/jfree/chart/title/CompositeTitleTest.java
+++ b/src/test/java/org/jfree/chart/title/CompositeTitleTest.java
@@ -154,7 +154,7 @@ public class CompositeTitleTest {
         t1.getContainer().add(new TextTitle("T1"));
         t1.setBackgroundPaint(new GradientPaint(1.0f, 2.0f, Color.RED,
                 3.0f, 4.0f, Color.BLUE));
-        CompositeTitle t2 = (CompositeTitle) TestUtils.serialised(t1);
+        CompositeTitle t2 = TestUtils.serialised(t1);
         assertEquals(t1, t2);
     }
 

--- a/src/test/java/org/jfree/chart/title/DateTitleTest.java
+++ b/src/test/java/org/jfree/chart/title/DateTitleTest.java
@@ -114,7 +114,7 @@ public class DateTitleTest {
     @Test
     public void testSerialization() {
         DateTitle t1 = new DateTitle();
-        DateTitle t2 = (DateTitle) TestUtils.serialised(t1);
+        DateTitle t2 = TestUtils.serialised(t1);
         assertEquals(t1, t2);
     }
 

--- a/src/test/java/org/jfree/chart/title/LegendGraphicTest.java
+++ b/src/test/java/org/jfree/chart/title/LegendGraphicTest.java
@@ -220,7 +220,7 @@ public class LegendGraphicTest {
         LegendGraphic g1 = new LegendGraphic(new Rectangle2D.Double(1.0, 2.0, 
                 3.0, 4.0), Color.BLACK);
         g1.setOutlineStroke(s);
-        LegendGraphic g2 = (LegendGraphic) TestUtils.serialised(g1);
+        LegendGraphic g2 = TestUtils.serialised(g1);
         assertTrue(g1.equals(g2));
     }
 

--- a/src/test/java/org/jfree/chart/title/LegendGraphicTest.java
+++ b/src/test/java/org/jfree/chart/title/LegendGraphicTest.java
@@ -42,10 +42,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.awt.BasicStroke;
 import java.awt.Color;
+import java.awt.Font;
 import java.awt.Rectangle;
 import java.awt.Stroke;
 import java.awt.geom.Line2D;
 import java.awt.geom.Rectangle2D;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 
 import org.jfree.chart.TestUtils;
 import org.jfree.chart.ui.GradientPaintTransformType;
@@ -58,6 +61,21 @@ import org.junit.jupiter.api.Test;
  * Tests for the {@link LegendGraphic} class.
  */
 public class LegendGraphicTest {
+
+    @Test
+    public void testEqualsHashCode() {
+        EqualsVerifier.forClass(LegendGraphic.class)
+                .suppress(Warning.STRICT_INHERITANCE)
+                .suppress(Warning.NONFINAL_FIELDS)
+                .withRedefinedSuperclass()
+                .withPrefabValues(Rectangle2D.class,
+                                  TestUtils.createR2D(true),
+                                  TestUtils.createR2D(false))
+                .withPrefabValues(Font.class,
+                                  TestUtils.createFont(true),
+                                  TestUtils.createFont(false))
+                .verify();
+    }
 
     /**
      * Check that the equals() method distinguishes all fields.

--- a/src/test/java/org/jfree/chart/title/LegendTitleTest.java
+++ b/src/test/java/org/jfree/chart/title/LegendTitleTest.java
@@ -44,6 +44,8 @@ import java.awt.Color;
 import java.awt.Font;
 import java.awt.GradientPaint;
 import java.awt.geom.Rectangle2D;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 
 import org.jfree.chart.TestUtils;
 
@@ -57,6 +59,25 @@ import org.junit.jupiter.api.Test;
  * Some tests for the {@link LegendTitle} class.
  */
 public class LegendTitleTest {
+
+    /**
+     * Use EqualsVerifier to test that the contract between equals and hashCode
+     * is properly implemented.
+     */
+    @Test
+    public void testEqualsHashCode() {
+        EqualsVerifier.forClass(LegendTitle.class)
+                .suppress(Warning.STRICT_INHERITANCE)
+                .suppress(Warning.NONFINAL_FIELDS)
+                .withRedefinedSuperclass()
+                .withPrefabValues(Rectangle2D.class,
+                                  TestUtils.createR2D(true),
+                                  TestUtils.createR2D(false))
+                .withPrefabValues(Font.class,
+                                  TestUtils.createFont(true),
+                                  TestUtils.createFont(false))
+                .verify();
+    }
 
     /**
      * Check that the equals() method distinguishes all fields.

--- a/src/test/java/org/jfree/chart/title/LegendTitleTest.java
+++ b/src/test/java/org/jfree/chart/title/LegendTitleTest.java
@@ -147,7 +147,7 @@ public class LegendTitleTest {
     public void testSerialization() {
         XYPlot plot = new XYPlot();
         LegendTitle t1 = new LegendTitle(plot);
-        LegendTitle t2 = (LegendTitle) TestUtils.serialised(t1);
+        LegendTitle t2 = TestUtils.serialised(t1);
         assertTrue(t1.equals(t2));
         assertTrue(t2.getSources()[0].equals(plot));
     }

--- a/src/test/java/org/jfree/chart/title/PaintScaleLegendTest.java
+++ b/src/test/java/org/jfree/chart/title/PaintScaleLegendTest.java
@@ -30,7 +30,7 @@
  * (C) Copyright 2007-2021, by David Gilbert and Contributors.
  *
  * Original Author:  David Gilbert;
- * Contributor(s):   -;
+ * Contributor(s):   Tracy Hiltbrand;
  *
  */
 
@@ -42,20 +42,49 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.awt.BasicStroke;
 import java.awt.Color;
+import java.awt.Font;
 import java.awt.GradientPaint;
+import java.awt.geom.Rectangle2D;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 
 import org.jfree.chart.TestUtils;
 
 import org.jfree.chart.axis.AxisLocation;
 import org.jfree.chart.axis.NumberAxis;
+import org.jfree.chart.axis.ValueAxis;
+import org.jfree.chart.plot.Plot;
 import org.jfree.chart.renderer.GrayPaintScale;
 import org.jfree.chart.renderer.LookupPaintScale;
 import org.junit.jupiter.api.Test;
+
+import org.jfree.chart.util.PaintUtils;
 
 /**
  * Tests for the {@link PaintScaleLegend} class.
  */
 public class PaintScaleLegendTest {
+
+    @Test
+    public void testEqualsHashCode() {
+        EqualsVerifier.forClass(PaintScaleLegend.class)
+                .suppress(Warning.STRICT_INHERITANCE)
+                .suppress(Warning.NONFINAL_FIELDS)
+                .withRedefinedSuperclass()
+                .withPrefabValues(Rectangle2D.class,
+                                  TestUtils.createR2D(true),
+                                  TestUtils.createR2D(false))
+                .withPrefabValues(Font.class, 
+                                  TestUtils.createFont(true),
+                                  TestUtils.createFont(false))
+                .withPrefabValues(Plot.class,
+                              TestUtils.createPlot(true),
+                              TestUtils.createPlot(false))
+                .withPrefabValues(ValueAxis.class,
+                                  TestUtils.createValueAxis(true),
+                                  TestUtils.createValueAxis(false))
+            .verify();
+    }
 
     /**
      * Test that the equals() method distinguishes all fields.
@@ -110,24 +139,28 @@ public class PaintScaleLegendTest {
         // stripOutlinePaint
         l1.setStripOutlinePaint(new GradientPaint(1.0f, 2.0f, Color.RED,
                 3.0f, 4.0f, Color.BLUE));
-        assertFalse(l1.equals(l2));
+        assertFalse(PaintUtils.equal(l1.getStripOutlinePaint(),
+                                     l2.getStripOutlinePaint()));
         l2.setStripOutlinePaint(new GradientPaint(1.0f, 2.0f, Color.RED,
                 3.0f, 4.0f, Color.BLUE));
-        assertTrue(l1.equals(l2));
+        assertTrue(PaintUtils.equal(l1.getStripOutlinePaint(),
+                                    l2.getStripOutlinePaint()));
 
         // stripOutlineStroke
         l1.setStripOutlineStroke(new BasicStroke(1.1f));
-        assertFalse(l1.equals(l2));
+        assertFalse(l1.getStripOutlineStroke().equals(l2.getStripOutlineStroke()));
         l2.setStripOutlineStroke(new BasicStroke(1.1f));
-        assertTrue(l1.equals(l2));
+        assertTrue(l1.getStripOutlineStroke().equals(l2.getStripOutlineStroke()));
 
         // backgroundPaint
         l1.setBackgroundPaint(new GradientPaint(1.0f, 2.0f, Color.RED,
                 3.0f, 4.0f, Color.BLUE));
-        assertFalse(l1.equals(l2));
+        assertFalse(PaintUtils.equal(l1.getBackgroundPaint(),
+                                     l2.getBackgroundPaint()));
         l2.setBackgroundPaint(new GradientPaint(1.0f, 2.0f, Color.RED,
                 3.0f, 4.0f, Color.BLUE));
-        assertTrue(l1.equals(l2));
+        assertTrue(PaintUtils.equal(l1.getBackgroundPaint(),
+                                    l2.getBackgroundPaint()));
 
         l1.setSubdivisionCount(99);
         assertFalse(l1.equals(l2));

--- a/src/test/java/org/jfree/chart/title/PaintScaleLegendTest.java
+++ b/src/test/java/org/jfree/chart/title/PaintScaleLegendTest.java
@@ -171,7 +171,7 @@ public class PaintScaleLegendTest {
     public void testSerialization() {
         PaintScaleLegend l1 = new PaintScaleLegend(new GrayPaintScale(),
                 new NumberAxis("X"));
-        PaintScaleLegend l2 = (PaintScaleLegend) TestUtils.serialised(l1);
+        PaintScaleLegend l2 = TestUtils.serialised(l1);
         assertEquals(l1, l2);
     }
 

--- a/src/test/java/org/jfree/chart/title/ShortTextTitleTest.java
+++ b/src/test/java/org/jfree/chart/title/ShortTextTitleTest.java
@@ -94,7 +94,7 @@ public class ShortTextTitleTest {
     @Test
     public void testSerialization() {
         ShortTextTitle t1 = new ShortTextTitle("ABC");
-        ShortTextTitle t2 = (ShortTextTitle) TestUtils.serialised(t1);
+        ShortTextTitle t2 = TestUtils.serialised(t1);
         assertEquals(t1, t2);
     }
 

--- a/src/test/java/org/jfree/chart/title/TextTitleTest.java
+++ b/src/test/java/org/jfree/chart/title/TextTitleTest.java
@@ -30,7 +30,7 @@
  * (C) Copyright 2004-2021, by David Gilbert and Contributors.
  *
  * Original Author:  David Gilbert;
- * Contributor(s):   -;
+ * Contributor(s):   Tracy Hiltbrand;
  *
  */
 
@@ -43,6 +43,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.awt.Color;
 import java.awt.Font;
 import java.awt.GradientPaint;
+import java.awt.geom.Rectangle2D;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 
 import org.jfree.chart.TestUtils;
 import org.jfree.chart.ui.HorizontalAlignment;
@@ -53,7 +56,20 @@ import org.junit.jupiter.api.Test;
  * Tests for the {@link TextTitle} class.
  */
 public class TextTitleTest {
-
+    @Test
+    public void testEqualsHashCode() {
+        EqualsVerifier.forClass(TextTitle.class)
+                .suppress(Warning.STRICT_INHERITANCE)
+                .suppress(Warning.NONFINAL_FIELDS)
+                .withRedefinedSuperclass()
+                .withPrefabValues(Rectangle2D.class,
+                                  TestUtils.createR2D(true),
+                                  TestUtils.createR2D(false))
+                .withPrefabValues(Font.class,
+                                  TestUtils.createFont(true),
+                                  TestUtils.createFont(false))
+                .verify();
+    }
     /**
      * Check that the equals() method distinguishes all fields.
      */

--- a/src/test/java/org/jfree/chart/title/TextTitleTest.java
+++ b/src/test/java/org/jfree/chart/title/TextTitleTest.java
@@ -152,7 +152,7 @@ public class TextTitleTest {
     @Test
     public void testSerialization() {
         TextTitle t1 = new TextTitle("Test");
-        TextTitle t2 = (TextTitle) TestUtils.serialised(t1);
+        TextTitle t2 = TestUtils.serialised(t1);
         assertEquals(t1, t2);
     }
 

--- a/src/test/java/org/jfree/chart/title/TitleTest.java
+++ b/src/test/java/org/jfree/chart/title/TitleTest.java
@@ -36,6 +36,10 @@
 
 package org.jfree.chart.title;
 
+import java.awt.geom.Rectangle2D;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.jfree.chart.TestUtils;
 import org.jfree.chart.ui.HorizontalAlignment;
 import org.jfree.chart.ui.RectangleEdge;
 import org.jfree.chart.ui.VerticalAlignment;
@@ -49,7 +53,19 @@ import org.junit.jupiter.api.Test;
  * Tests for the abstract {@link Title} class.
  */
 public class TitleTest {
-
+    @Test
+    public void testEqualsHashCode() {
+        EqualsVerifier.forClass(Title.class)
+                .suppress(Warning.NONFINAL_FIELDS)
+                .withRedefinedSuperclass()
+                .withRedefinedSubclass(LegendTitle.class)
+                .withRedefinedSubclass(PaintScaleLegend.class)
+                .withPrefabValues(Rectangle2D.class,
+                                  TestUtils.createR2D(true),
+                                  TestUtils.createR2D(false))
+                .verify();
+    }
+	
     /**
      * Some checks for the equals() method.
      */

--- a/src/test/java/org/jfree/chart/urls/CustomCategoryURLGeneratorTest.java
+++ b/src/test/java/org/jfree/chart/urls/CustomCategoryURLGeneratorTest.java
@@ -130,8 +130,7 @@ public class CustomCategoryURLGeneratorTest {
         CustomCategoryURLGenerator g1 = new CustomCategoryURLGenerator();
         g1.addURLSeries(u1);
         g1.addURLSeries(u2);
-        CustomCategoryURLGenerator g2 = (CustomCategoryURLGenerator) 
-                TestUtils.serialised(g1);
+        CustomCategoryURLGenerator g2 = TestUtils.serialised(g1);
         assertEquals(g1, g2);
     }
 

--- a/src/test/java/org/jfree/chart/urls/CustomPieURLGeneratorTest.java
+++ b/src/test/java/org/jfree/chart/urls/CustomPieURLGeneratorTest.java
@@ -109,8 +109,7 @@ public class CustomPieURLGeneratorTest {
         Map<String, String> m1 = new HashMap<>();
         m1.put("A", "http://www.jfree.org/");
         g1.addURLs(m1);
-        CustomPieURLGenerator g2 = (CustomPieURLGenerator) 
-                TestUtils.serialised(g1);
+        CustomPieURLGenerator g2 = TestUtils.serialised(g1);
         assertEquals(g1, g2);
     }
 

--- a/src/test/java/org/jfree/chart/urls/CustomXYURLGeneratorTest.java
+++ b/src/test/java/org/jfree/chart/urls/CustomXYURLGeneratorTest.java
@@ -128,8 +128,7 @@ public class CustomXYURLGeneratorTest {
         CustomXYURLGenerator g1 = new CustomXYURLGenerator();
         g1.addURLSeries(u1);
         g1.addURLSeries(u2);
-        CustomXYURLGenerator g2 = (CustomXYURLGenerator) 
-                TestUtils.serialised(g1);
+        CustomXYURLGenerator g2 = TestUtils.serialised(g1);
         assertEquals(g1, g2);
     }
 

--- a/src/test/java/org/jfree/chart/urls/StandardCategoryURLGeneratorTest.java
+++ b/src/test/java/org/jfree/chart/urls/StandardCategoryURLGeneratorTest.java
@@ -113,8 +113,7 @@ public class StandardCategoryURLGeneratorTest {
     public void testSerialization() {
         StandardCategoryURLGenerator g1 = new StandardCategoryURLGenerator(
                 "index.html?");
-        StandardCategoryURLGenerator g2 = (StandardCategoryURLGenerator) 
-                TestUtils.serialised(g1);
+        StandardCategoryURLGenerator g2 = TestUtils.serialised(g1);
         assertEquals(g1, g2);
     }
 

--- a/src/test/java/org/jfree/chart/urls/StandardPieURLGeneratorTest.java
+++ b/src/test/java/org/jfree/chart/urls/StandardPieURLGeneratorTest.java
@@ -104,8 +104,7 @@ public class StandardPieURLGeneratorTest {
     public void testSerialization() {
         StandardPieURLGenerator g1 = new StandardPieURLGenerator(
                 "index.html?", "cat");
-        StandardPieURLGenerator g2 = (StandardPieURLGenerator) 
-                TestUtils.serialised(g1);
+        StandardPieURLGenerator g2 = TestUtils.serialised(g1);
         assertEquals(g1, g2);
     }
 

--- a/src/test/java/org/jfree/chart/urls/StandardXYURLGeneratorTest.java
+++ b/src/test/java/org/jfree/chart/urls/StandardXYURLGeneratorTest.java
@@ -55,8 +55,7 @@ public class StandardXYURLGeneratorTest {
     @Test
     public void testSerialization() {
         StandardXYURLGenerator g1 = new StandardXYURLGenerator("index.html?");
-        StandardXYURLGenerator g2 = (StandardXYURLGenerator) 
-                TestUtils.serialised(g1);
+        StandardXYURLGenerator g2 = TestUtils.serialised(g1);
         assertEquals(g1, g2);
     }
 

--- a/src/test/java/org/jfree/chart/urls/TimeSeriesURLGeneratorTest.java
+++ b/src/test/java/org/jfree/chart/urls/TimeSeriesURLGeneratorTest.java
@@ -117,8 +117,7 @@ public class TimeSeriesURLGeneratorTest {
     @Test
     public void testSerialization() {
         TimeSeriesURLGenerator g1 = new TimeSeriesURLGenerator();
-        TimeSeriesURLGenerator g2 = (TimeSeriesURLGenerator) 
-                TestUtils.serialised(g1);
+        TimeSeriesURLGenerator g2 = TestUtils.serialised(g1);
         assertEquals(g1, g2);
     }
 

--- a/src/test/java/org/jfree/chart/util/LogFormatTest.java
+++ b/src/test/java/org/jfree/chart/util/LogFormatTest.java
@@ -110,7 +110,7 @@ public class LogFormatTest {
     @Test
     public void testSerialization() {
         LogFormat f1 = new LogFormat(10.0, "10", true);
-        LogFormat f2 = (LogFormat) TestUtils.serialised(f1);
+        LogFormat f2 = TestUtils.serialised(f1);
         assertEquals(f1, f2);
     }
 

--- a/src/test/java/org/jfree/data/ComparableObjectItemTest.java
+++ b/src/test/java/org/jfree/data/ComparableObjectItemTest.java
@@ -106,8 +106,7 @@ public class ComparableObjectItemTest {
     @Test
     public void testSerialization() {
         ComparableObjectItem item1 = new ComparableObjectItem(1, "XYZ");
-        ComparableObjectItem item2 = (ComparableObjectItem) 
-                TestUtils.serialised(item1);
+        ComparableObjectItem item2 = TestUtils.serialised(item1);
         assertEquals(item1, item2);
     }
 

--- a/src/test/java/org/jfree/data/ComparableObjectSeriesTest.java
+++ b/src/test/java/org/jfree/data/ComparableObjectSeriesTest.java
@@ -171,8 +171,7 @@ public class ComparableObjectSeriesTest {
     public void testSerialization() {
         MyComparableObjectSeries s1 = new MyComparableObjectSeries("A");
         s1.add(1, "ABC");
-        MyComparableObjectSeries s2 = (MyComparableObjectSeries) 
-                TestUtils.serialised(s1);
+        MyComparableObjectSeries s2 = TestUtils.serialised(s1);
         assertEquals(s1, s2);
     }
 

--- a/src/test/java/org/jfree/data/DefaultKeyedValueTest.java
+++ b/src/test/java/org/jfree/data/DefaultKeyedValueTest.java
@@ -126,7 +126,7 @@ public class DefaultKeyedValueTest {
     @Test
     public void testSerialization() {
         DefaultKeyedValue v1 = new DefaultKeyedValue("Test", 25.3);
-        DefaultKeyedValue v2 = (DefaultKeyedValue) TestUtils.serialised(v1);
+        DefaultKeyedValue v2 = TestUtils.serialised(v1);
         assertEquals(v1, v2);
     }
 

--- a/src/test/java/org/jfree/data/DefaultKeyedValues2DTest.java
+++ b/src/test/java/org/jfree/data/DefaultKeyedValues2DTest.java
@@ -106,8 +106,7 @@ public class DefaultKeyedValues2DTest {
         kv2D1.addValue(345.9, "Row2", "Col1");
         kv2D1.addValue(452.7, "Row2", "Col2");
 
-        DefaultKeyedValues2D kv2D2 = (DefaultKeyedValues2D) 
-                TestUtils.serialised(kv2D1);
+        DefaultKeyedValues2D kv2D2 = TestUtils.serialised(kv2D1);
         assertEquals(kv2D1, kv2D2);
     }
 

--- a/src/test/java/org/jfree/data/DefaultKeyedValuesTest.java
+++ b/src/test/java/org/jfree/data/DefaultKeyedValuesTest.java
@@ -483,8 +483,7 @@ public class DefaultKeyedValuesTest {
         v1.addValue("Key 2", null);
         v1.addValue("Key 3", 42);
 
-        DefaultKeyedValues v2 = (DefaultKeyedValues) 
-                TestUtils.serialised(v1);
+        DefaultKeyedValues v2 = TestUtils.serialised(v1);
         assertEquals(v1, v2);
     }
 

--- a/src/test/java/org/jfree/data/DomainOrderTest.java
+++ b/src/test/java/org/jfree/data/DomainOrderTest.java
@@ -86,7 +86,7 @@ public class DomainOrderTest {
     @Test
     public void testSerialization() {
         DomainOrder d1 = DomainOrder.ASCENDING;
-        DomainOrder d2 = (DomainOrder) TestUtils.serialised(d1);
+        DomainOrder d2 = TestUtils.serialised(d1);
         assertSame(d1, d2);
     }
 

--- a/src/test/java/org/jfree/data/KeyToGroupMapTest.java
+++ b/src/test/java/org/jfree/data/KeyToGroupMapTest.java
@@ -239,7 +239,7 @@ public class KeyToGroupMapTest {
     @Test
     public void testSerialization() {
         KeyToGroupMap m1 = new KeyToGroupMap("Test");
-        KeyToGroupMap m2 = (KeyToGroupMap) TestUtils.serialised(m1);
+        KeyToGroupMap m2 = TestUtils.serialised(m1);
         assertEquals(m1, m2);
     }
 

--- a/src/test/java/org/jfree/data/KeyedObjectTest.java
+++ b/src/test/java/org/jfree/data/KeyedObjectTest.java
@@ -119,7 +119,7 @@ public class KeyedObjectTest {
     @Test
     public void testSerialization() {
         KeyedObject ko1 = new KeyedObject("Test", "Object");
-        KeyedObject ko2 = (KeyedObject) TestUtils.serialised(ko1);
+        KeyedObject ko2 = TestUtils.serialised(ko1);
         assertEquals(ko1, ko2);
     }
 

--- a/src/test/java/org/jfree/data/KeyedObjects2DTest.java
+++ b/src/test/java/org/jfree/data/KeyedObjects2DTest.java
@@ -95,7 +95,7 @@ public class KeyedObjects2DTest {
         ko2D1.addObject(345.9, "Row2", "Col1");
         ko2D1.addObject(452.7, "Row2", "Col2");
 
-        KeyedObjects2D ko2D2 = (KeyedObjects2D) TestUtils.serialised(ko2D1);
+        KeyedObjects2D ko2D2 = TestUtils.serialised(ko2D1);
         assertEquals(ko2D1, ko2D2);
     }
 

--- a/src/test/java/org/jfree/data/KeyedObjectsTest.java
+++ b/src/test/java/org/jfree/data/KeyedObjectsTest.java
@@ -150,7 +150,7 @@ public class KeyedObjectsTest {
         ko1.addObject("Key 1", "Object 1");
         ko1.addObject("Key 2", null);
         ko1.addObject("Key 3", "Object 2");
-        KeyedObjects ko2 = (KeyedObjects) TestUtils.serialised(ko1);
+        KeyedObjects ko2 = TestUtils.serialised(ko1);
         assertEquals(ko1, ko2);
     }
 

--- a/src/test/java/org/jfree/data/RangeTest.java
+++ b/src/test/java/org/jfree/data/RangeTest.java
@@ -286,7 +286,7 @@ public class RangeTest {
     @Test
     public void testSerialization() {
         Range r1 = new Range(25.0, 133.42);
-        Range r2 = (Range) TestUtils.serialised(r1);
+        Range r2 = TestUtils.serialised(r1);
         assertEquals(r1, r2);
     }
 

--- a/src/test/java/org/jfree/data/RangeTypeTest.java
+++ b/src/test/java/org/jfree/data/RangeTypeTest.java
@@ -86,7 +86,7 @@ public class RangeTypeTest {
     @Test
     public void testSerialization() {
         RangeType r1 = RangeType.FULL;
-        RangeType r2 = (RangeType) TestUtils.serialised(r1);
+        RangeType r2 = TestUtils.serialised(r1);
         assertSame(r1, r2);
     }
 

--- a/src/test/java/org/jfree/data/category/CategoryToPieDatasetTest.java
+++ b/src/test/java/org/jfree/data/category/CategoryToPieDatasetTest.java
@@ -201,8 +201,7 @@ public class CategoryToPieDatasetTest {
         underlying.addValue(2.2, "R1", "C2");
         CategoryToPieDataset d1 = new CategoryToPieDataset(underlying,
                 TableOrder.BY_COLUMN, 1);
-        CategoryToPieDataset d2 = (CategoryToPieDataset) 
-                TestUtils.serialised(d1);
+        CategoryToPieDataset d2 = TestUtils.serialised(d1);
         assertEquals(d1, d2);
 
         // regular equality for the datasets doesn't check the fields, just

--- a/src/test/java/org/jfree/data/category/DefaultCategoryDatasetTest.java
+++ b/src/test/java/org/jfree/data/category/DefaultCategoryDatasetTest.java
@@ -204,8 +204,7 @@ public class DefaultCategoryDatasetTest {
     public void testSerialization() {
         DefaultCategoryDataset d1 = new DefaultCategoryDataset();
         d1.setValue(23.4, "R1", "C1");
-        DefaultCategoryDataset d2 = (DefaultCategoryDataset) 
-                TestUtils.serialised(d1);
+        DefaultCategoryDataset d2 = TestUtils.serialised(d1);
         assertEquals(d1, d2);
     }
 

--- a/src/test/java/org/jfree/data/category/DefaultIntervalCategoryDatasetTest.java
+++ b/src/test/java/org/jfree/data/category/DefaultIntervalCategoryDatasetTest.java
@@ -170,8 +170,7 @@ public class DefaultIntervalCategoryDatasetTest {
         double[][] ends = new double[][] {ends_S1, ends_S2};
         DefaultIntervalCategoryDataset d1
                 = new DefaultIntervalCategoryDataset(starts, ends);
-        DefaultIntervalCategoryDataset d2 = (DefaultIntervalCategoryDataset) 
-                TestUtils.serialised(d1);
+        DefaultIntervalCategoryDataset d2 = TestUtils.serialised(d1);
         assertEquals(d1, d2);
     }
 

--- a/src/test/java/org/jfree/data/category/SlidingCategoryDatasetTest.java
+++ b/src/test/java/org/jfree/data/category/SlidingCategoryDatasetTest.java
@@ -117,8 +117,7 @@ public class SlidingCategoryDatasetTest {
         u1.addValue(1.0, "R1", "C1");
         u1.addValue(2.0, "R1", "C2");
         SlidingCategoryDataset d1 = new SlidingCategoryDataset(u1, 0, 5);
-        SlidingCategoryDataset d2 = (SlidingCategoryDataset) 
-                TestUtils.serialised(d1);
+        SlidingCategoryDataset d2 = TestUtils.serialised(d1);
         assertEquals(d1, d2);
 
         // basic check for independence

--- a/src/test/java/org/jfree/data/function/LineFunction2DTest.java
+++ b/src/test/java/org/jfree/data/function/LineFunction2DTest.java
@@ -80,7 +80,7 @@ public class LineFunction2DTest {
     @Test
     public void testSerialization() {
         LineFunction2D f1 = new LineFunction2D(1.0, 2.0);
-        LineFunction2D f2 = (LineFunction2D) TestUtils.serialised(f1);
+        LineFunction2D f2 = TestUtils.serialised(f1);
         assertEquals(f1, f2);
     }
 

--- a/src/test/java/org/jfree/data/function/NormalDistributionFunction2DTest.java
+++ b/src/test/java/org/jfree/data/function/NormalDistributionFunction2DTest.java
@@ -82,8 +82,7 @@ public class NormalDistributionFunction2DTest {
     public void testSerialization() {
         NormalDistributionFunction2D f1 = new NormalDistributionFunction2D(1.0,
                 2.0);
-        NormalDistributionFunction2D f2 = (NormalDistributionFunction2D) 
-                TestUtils.serialised(f1);
+        NormalDistributionFunction2D f2 = TestUtils.serialised(f1);
         assertEquals(f1, f2);
     }
 

--- a/src/test/java/org/jfree/data/function/PolynomialFunction2DTest.java
+++ b/src/test/java/org/jfree/data/function/PolynomialFunction2DTest.java
@@ -116,8 +116,7 @@ public class PolynomialFunction2DTest {
     public void testSerialization() {
         PolynomialFunction2D f1 = new PolynomialFunction2D(new double[] {1.0,
                 2.0});
-        PolynomialFunction2D f2 = (PolynomialFunction2D) 
-                TestUtils.serialised(f1);
+        PolynomialFunction2D f2 = TestUtils.serialised(f1);
         assertEquals(f1, f2);
     }
 

--- a/src/test/java/org/jfree/data/function/PowerFunction2DTest.java
+++ b/src/test/java/org/jfree/data/function/PowerFunction2DTest.java
@@ -79,7 +79,7 @@ public class PowerFunction2DTest {
     @Test
     public void testSerialization() {
         PowerFunction2D f1 = new PowerFunction2D(1.0, 2.0);
-        PowerFunction2D f2 = (PowerFunction2D) TestUtils.serialised(f1);
+        PowerFunction2D f2 = TestUtils.serialised(f1);
         assertEquals(f1, f2);
     }
 

--- a/src/test/java/org/jfree/data/gantt/SlidingGanttCategoryDatasetTest.java
+++ b/src/test/java/org/jfree/data/gantt/SlidingGanttCategoryDatasetTest.java
@@ -126,8 +126,7 @@ public class SlidingGanttCategoryDatasetTest {
         u1.add(s1);
         SlidingGanttCategoryDataset d1 = new SlidingGanttCategoryDataset(
                 u1, 0, 5);
-        SlidingGanttCategoryDataset d2 = (SlidingGanttCategoryDataset) 
-                TestUtils.serialised(d1);
+        SlidingGanttCategoryDataset d2 = TestUtils.serialised(d1);
         assertEquals(d1, d2);
 
         // basic check for independence

--- a/src/test/java/org/jfree/data/gantt/TaskSeriesCollectionTest.java
+++ b/src/test/java/org/jfree/data/gantt/TaskSeriesCollectionTest.java
@@ -490,8 +490,7 @@ public class TaskSeriesCollectionTest {
         TaskSeriesCollection c1 = new TaskSeriesCollection();
         c1.add(s1);
         c1.add(s2);
-        TaskSeriesCollection c2 = (TaskSeriesCollection) 
-                TestUtils.serialised(c1);
+        TaskSeriesCollection c2 = TestUtils.serialised(c1);
         assertEquals(c1, c2);
     }
 

--- a/src/test/java/org/jfree/data/gantt/TaskSeriesTest.java
+++ b/src/test/java/org/jfree/data/gantt/TaskSeriesTest.java
@@ -97,7 +97,7 @@ public class TaskSeriesTest {
         TaskSeries s1 = new TaskSeries("S");
         s1.add(new Task("T1", new Date(1), new Date(2)));
         s1.add(new Task("T2", new Date(11), new Date(22)));
-        TaskSeries s2 = (TaskSeries) TestUtils.serialised(s1);
+        TaskSeries s2 = TestUtils.serialised(s1);
         assertEquals(s1, s2);
     }
 

--- a/src/test/java/org/jfree/data/gantt/TaskTest.java
+++ b/src/test/java/org/jfree/data/gantt/TaskTest.java
@@ -102,7 +102,7 @@ public class TaskTest {
     @Test
     public void testSerialization() {
         Task t1 = new Task("T", new Date(1), new Date(2));
-        Task t2 = (Task) TestUtils.serialised(t1);
+        Task t2 = TestUtils.serialised(t1);
         assertEquals(t1, t2);
     }
 

--- a/src/test/java/org/jfree/data/gantt/XYTaskDatasetTest.java
+++ b/src/test/java/org/jfree/data/gantt/XYTaskDatasetTest.java
@@ -120,7 +120,7 @@ public class XYTaskDatasetTest {
         TaskSeriesCollection u1 = new TaskSeriesCollection();
         u1.add(s1);
         XYTaskDataset d1 = new XYTaskDataset(u1);
-        XYTaskDataset d2 = (XYTaskDataset) TestUtils.serialised(d1);
+        XYTaskDataset d2 = TestUtils.serialised(d1);
         assertEquals(d1, d2);
 
         // basic check for independence

--- a/src/test/java/org/jfree/data/general/DatasetGroupTest.java
+++ b/src/test/java/org/jfree/data/general/DatasetGroupTest.java
@@ -51,7 +51,7 @@ public class DatasetGroupTest {
     @Test
     public void testSerialization() {
         DatasetGroup g1 = new DatasetGroup();
-        DatasetGroup g2 = (DatasetGroup) TestUtils.serialised(g1);
+        DatasetGroup g2 = TestUtils.serialised(g1);
         assertEquals(g1, g2);
     }
 

--- a/src/test/java/org/jfree/data/general/DefaultHeatMapDatasetTest.java
+++ b/src/test/java/org/jfree/data/general/DefaultHeatMapDatasetTest.java
@@ -183,8 +183,7 @@ public class DefaultHeatMapDatasetTest implements DatasetChangeListener {
         d1.setZValue(0, 1, Double.NEGATIVE_INFINITY);
         d1.setZValue(0, 2, Double.POSITIVE_INFINITY);
         d1.setZValue(1, 0, Double.NaN);
-        DefaultHeatMapDataset d2 = (DefaultHeatMapDataset) 
-                TestUtils.serialised(d1);
+        DefaultHeatMapDataset d2 = TestUtils.serialised(d1);
         assertEquals(d1, d2);
     }
 

--- a/src/test/java/org/jfree/data/general/DefaultKeyedValueDatasetTest.java
+++ b/src/test/java/org/jfree/data/general/DefaultKeyedValueDatasetTest.java
@@ -109,8 +109,7 @@ public class DefaultKeyedValueDatasetTest {
     public void testSerialization() {
         DefaultKeyedValueDataset d1
                 = new DefaultKeyedValueDataset("Test", 25.3);
-        DefaultKeyedValueDataset d2 = (DefaultKeyedValueDataset) 
-                TestUtils.serialised(d1);
+        DefaultKeyedValueDataset d2 = TestUtils.serialised(d1);
         assertEquals(d1, d2);
     }
 

--- a/src/test/java/org/jfree/data/general/DefaultKeyedValues2DDatasetTest.java
+++ b/src/test/java/org/jfree/data/general/DefaultKeyedValues2DDatasetTest.java
@@ -76,8 +76,7 @@ public class DefaultKeyedValues2DDatasetTest {
         d1.addValue(345.9, "Row2", "Col1");
         d1.addValue(452.7, "Row2", "Col2");
 
-        DefaultKeyedValues2DDataset d2 = (DefaultKeyedValues2DDataset) 
-                TestUtils.serialised(d1);
+        DefaultKeyedValues2DDataset d2 = TestUtils.serialised(d1);
         assertEquals(d1, d2);
     }
 

--- a/src/test/java/org/jfree/data/general/DefaultKeyedValuesDatasetTest.java
+++ b/src/test/java/org/jfree/data/general/DefaultKeyedValuesDatasetTest.java
@@ -72,8 +72,7 @@ public class DefaultKeyedValuesDatasetTest {
         d1.setValue("C3", 345.9);
         d1.setValue("C4", 452.7);
 
-        KeyedValuesDataset d2 = (KeyedValuesDataset) 
-                TestUtils.serialised(d1);
+        KeyedValuesDataset d2 = TestUtils.serialised(d1);
         assertEquals(d1, d2);
     }
 

--- a/src/test/java/org/jfree/data/general/DefaultPieDatasetTest.java
+++ b/src/test/java/org/jfree/data/general/DefaultPieDatasetTest.java
@@ -160,7 +160,7 @@ public class DefaultPieDatasetTest implements DatasetChangeListener {
         d1.setValue("C3", 345.9);
         d1.setValue("C4", 452.7);
 
-        DefaultPieDataset d2 = (DefaultPieDataset) TestUtils.serialised(d1);
+        DefaultPieDataset d2 = TestUtils.serialised(d1);
         assertEquals(d1, d2);
     }
 

--- a/src/test/java/org/jfree/data/statistics/BoxAndWhiskerItemTest.java
+++ b/src/test/java/org/jfree/data/statistics/BoxAndWhiskerItemTest.java
@@ -69,7 +69,7 @@ public class BoxAndWhiskerItemTest {
     public void testSerialization() {
         BoxAndWhiskerItem i1 = new BoxAndWhiskerItem(1.0, 2.0, 3.0, 4.0,
                 5.0, 6.0, 7.0, 8.0, new ArrayList<Double>());
-        BoxAndWhiskerItem i2 = (BoxAndWhiskerItem) TestUtils.serialised(i1);
+        BoxAndWhiskerItem i2 = TestUtils.serialised(i1);
         assertEquals(i1, i2);
     }
 

--- a/src/test/java/org/jfree/data/statistics/DefaultBoxAndWhiskerCategoryDatasetTest.java
+++ b/src/test/java/org/jfree/data/statistics/DefaultBoxAndWhiskerCategoryDatasetTest.java
@@ -79,8 +79,7 @@ public class DefaultBoxAndWhiskerCategoryDatasetTest {
                 = new DefaultBoxAndWhiskerCategoryDataset();
         d1.add(new BoxAndWhiskerItem(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0,
                 new ArrayList<Double>()), "ROW1", "COLUMN1");
-        DefaultBoxAndWhiskerCategoryDataset d2 = 
-                (DefaultBoxAndWhiskerCategoryDataset) TestUtils.serialised(d1);
+        DefaultBoxAndWhiskerCategoryDataset d2 = TestUtils.serialised(d1);
         assertEquals(d1, d2);
     }
 

--- a/src/test/java/org/jfree/data/statistics/DefaultMultiValueCategoryDatasetTest.java
+++ b/src/test/java/org/jfree/data/statistics/DefaultMultiValueCategoryDatasetTest.java
@@ -179,8 +179,7 @@ public class DefaultMultiValueCategoryDatasetTest {
     public void testSerialization() {
         DefaultMultiValueCategoryDataset d1
                 = new DefaultMultiValueCategoryDataset();
-        DefaultMultiValueCategoryDataset d2 = (DefaultMultiValueCategoryDataset)
-                TestUtils.serialised(d1);
+        DefaultMultiValueCategoryDataset d2 = TestUtils.serialised(d1);
         assertEquals(d1, d2);
     }
 

--- a/src/test/java/org/jfree/data/statistics/DefaultStatisticalCategoryDatasetTest.java
+++ b/src/test/java/org/jfree/data/statistics/DefaultStatisticalCategoryDatasetTest.java
@@ -145,8 +145,7 @@ public class DefaultStatisticalCategoryDatasetTest {
         d1.add(3.3, 4.4, "R1", "C2");
         d1.add(null, 5.5, "R1", "C3");
         d1.add(6.6, null, "R2", "C3");
-        DefaultStatisticalCategoryDataset d2 = 
-                (DefaultStatisticalCategoryDataset) TestUtils.serialised(d1);
+        DefaultStatisticalCategoryDataset d2 = TestUtils.serialised(d1);
         assertEquals(d1, d2);
     }
 
@@ -158,8 +157,7 @@ public class DefaultStatisticalCategoryDatasetTest {
         DefaultStatisticalCategoryDataset d1
             = new DefaultStatisticalCategoryDataset();
         d1.add(1.2, 3.4, "Row 1", "Column 1");
-        DefaultStatisticalCategoryDataset d2 = 
-                (DefaultStatisticalCategoryDataset) TestUtils.serialised(d1);
+        DefaultStatisticalCategoryDataset d2 = TestUtils.serialised(d1);
         assertEquals(d1, d2);
     }
 

--- a/src/test/java/org/jfree/data/statistics/HistogramBinTest.java
+++ b/src/test/java/org/jfree/data/statistics/HistogramBinTest.java
@@ -81,7 +81,7 @@ public class HistogramBinTest {
         double start = 10.0;
         double end = 20.0;
         HistogramBin b1 = new HistogramBin(start, end);
-        HistogramBin b2 = (HistogramBin) TestUtils.serialised(b1);
+        HistogramBin b2 = TestUtils.serialised(b1);
         assertEquals(b1, b2);
     }
 

--- a/src/test/java/org/jfree/data/statistics/HistogramDatasetTest.java
+++ b/src/test/java/org/jfree/data/statistics/HistogramDatasetTest.java
@@ -117,7 +117,7 @@ public class HistogramDatasetTest implements DatasetChangeListener {
         double[] values = {1.0, 2.0, 3.0, 4.0, 6.0, 12.0, 5.0, 6.3, 4.5};
         HistogramDataset d1 = new HistogramDataset();
         d1.addSeries("Series 1", values, 5);
-        HistogramDataset d2 = (HistogramDataset) TestUtils.serialised(d1);
+        HistogramDataset d2 = TestUtils.serialised(d1);
         assertEquals(d1, d2);
 
         // simple check for independence

--- a/src/test/java/org/jfree/data/statistics/MeanAndStandardDeviationTest.java
+++ b/src/test/java/org/jfree/data/statistics/MeanAndStandardDeviationTest.java
@@ -84,8 +84,7 @@ public class MeanAndStandardDeviationTest {
     @Test
     public void testSerialization() {
         MeanAndStandardDeviation m1 = new MeanAndStandardDeviation(1.2, 3.4);
-        MeanAndStandardDeviation m2 = (MeanAndStandardDeviation) 
-                TestUtils.serialised(m1);
+        MeanAndStandardDeviation m2 = TestUtils.serialised(m1);
         assertEquals(m1, m2);
     }
 }

--- a/src/test/java/org/jfree/data/statistics/SimpleHistogramBinTest.java
+++ b/src/test/java/org/jfree/data/statistics/SimpleHistogramBinTest.java
@@ -154,7 +154,7 @@ public class SimpleHistogramBinTest {
     public void testSerialization() {
         SimpleHistogramBin b1 = new SimpleHistogramBin(1.0, 2.0, false, true);
         b1.setItemCount(123);
-        SimpleHistogramBin b2 = (SimpleHistogramBin) TestUtils.serialised(b1);
+        SimpleHistogramBin b2 = TestUtils.serialised(b1);
         assertEquals(b1, b2);
     }
 

--- a/src/test/java/org/jfree/data/statistics/SimpleHistogramDatasetTest.java
+++ b/src/test/java/org/jfree/data/statistics/SimpleHistogramDatasetTest.java
@@ -86,8 +86,7 @@ public class SimpleHistogramDatasetTest {
     @Test
     public void testSerialization() {
         SimpleHistogramDataset d1 = new SimpleHistogramDataset("D1");
-        SimpleHistogramDataset d2 = (SimpleHistogramDataset) 
-                TestUtils.serialised(d1);
+        SimpleHistogramDataset d2 = TestUtils.serialised(d1);
         assertEquals(d1, d2);
     }
 

--- a/src/test/java/org/jfree/data/time/DateRangeTest.java
+++ b/src/test/java/org/jfree/data/time/DateRangeTest.java
@@ -77,7 +77,7 @@ public class DateRangeTest {
     @Test
     public void testSerialization() {
         DateRange r1 = new DateRange(new Date(1000L), new Date(2000L));
-        DateRange r2 = (DateRange) TestUtils.serialised(r1);
+        DateRange r2 = TestUtils.serialised(r1);
         assertEquals(r1, r2);
     }
 

--- a/src/test/java/org/jfree/data/time/DayTest.java
+++ b/src/test/java/org/jfree/data/time/DayTest.java
@@ -315,7 +315,7 @@ public class DayTest {
     @Test
     public void testSerialization() {
         Day d1 = new Day(15, 4, 2000);
-        Day d2 = (Day) TestUtils.serialised(d1);
+        Day d2 = TestUtils.serialised(d1);
         assertEquals(d1, d2);
     }
 

--- a/src/test/java/org/jfree/data/time/FixedMillisecondTest.java
+++ b/src/test/java/org/jfree/data/time/FixedMillisecondTest.java
@@ -56,7 +56,7 @@ public class FixedMillisecondTest {
     @Test
     public void testSerialization() {
         FixedMillisecond m1 = new FixedMillisecond();
-        FixedMillisecond m2 = (FixedMillisecond) TestUtils.serialised(m1);
+        FixedMillisecond m2 = TestUtils.serialised(m1);
         assertEquals(m1, m2);
     }
 

--- a/src/test/java/org/jfree/data/time/HourTest.java
+++ b/src/test/java/org/jfree/data/time/HourTest.java
@@ -261,7 +261,7 @@ public class HourTest {
     @Test
     public void testSerialization() {
         Hour h1 = new Hour();
-        Hour h2 = (Hour) TestUtils.serialised(h1);
+        Hour h2 = TestUtils.serialised(h1);
         assertEquals(h1, h2);
     }
 

--- a/src/test/java/org/jfree/data/time/MillisecondTest.java
+++ b/src/test/java/org/jfree/data/time/MillisecondTest.java
@@ -224,7 +224,7 @@ public class MillisecondTest {
     @Test
     public void testSerialization() {
         Millisecond m1 = new Millisecond();
-        Millisecond m2 = (Millisecond) TestUtils.serialised(m1);
+        Millisecond m2 = TestUtils.serialised(m1);
         assertEquals(m1, m2);
     }
 

--- a/src/test/java/org/jfree/data/time/MinuteTest.java
+++ b/src/test/java/org/jfree/data/time/MinuteTest.java
@@ -211,7 +211,7 @@ public class MinuteTest {
     @Test
     public void testSerialization() {
         Minute m1 = new Minute();
-        Minute m2 = (Minute) TestUtils.serialised(m1);
+        Minute m2 = TestUtils.serialised(m1);
         assertEquals(m1, m2);
     }
 

--- a/src/test/java/org/jfree/data/time/MonthTest.java
+++ b/src/test/java/org/jfree/data/time/MonthTest.java
@@ -346,7 +346,7 @@ public class MonthTest {
     @Test
     public void testSerialization() {
         Month m1 = new Month(12, 1999);
-        Month m2 = (Month) TestUtils.serialised(m1);
+        Month m2 = TestUtils.serialised(m1);
         assertEquals(m1, m2);
     }
 

--- a/src/test/java/org/jfree/data/time/QuarterTest.java
+++ b/src/test/java/org/jfree/data/time/QuarterTest.java
@@ -343,7 +343,7 @@ public class QuarterTest {
     @Test
     public void testSerialization() {
         Quarter q1 = new Quarter(4, 1999);
-        Quarter q2 = (Quarter) TestUtils.serialised(q1);
+        Quarter q2 = TestUtils.serialised(q1);
         assertEquals(q1, q2);
     }
 

--- a/src/test/java/org/jfree/data/time/SecondTest.java
+++ b/src/test/java/org/jfree/data/time/SecondTest.java
@@ -214,7 +214,7 @@ public class SecondTest {
     @Test
     public void testSerialization() {
         Second s1 = new Second();
-        Second s2 = (Second) TestUtils.serialised(s1);
+        Second s2 = TestUtils.serialised(s1);
         assertEquals(s1, s2);
     }
 

--- a/src/test/java/org/jfree/data/time/SimpleTimePeriodTest.java
+++ b/src/test/java/org/jfree/data/time/SimpleTimePeriodTest.java
@@ -92,7 +92,7 @@ public class SimpleTimePeriodTest {
     public void testSerialization() {
         SimpleTimePeriod p1 = new SimpleTimePeriod(new Date(1000L),
                 new Date(1001L));
-        SimpleTimePeriod p2 = (SimpleTimePeriod) TestUtils.serialised(p1);
+        SimpleTimePeriod p2 = TestUtils.serialised(p1);
         assertEquals(p1, p2);
     }
 

--- a/src/test/java/org/jfree/data/time/TimePeriodAnchorTest.java
+++ b/src/test/java/org/jfree/data/time/TimePeriodAnchorTest.java
@@ -62,7 +62,7 @@ public class TimePeriodAnchorTest {
     @Test
     public void testSerialization() {
         TimePeriodAnchor a1 = TimePeriodAnchor.START;
-        TimePeriodAnchor a2 = (TimePeriodAnchor) TestUtils.serialised(a1);
+        TimePeriodAnchor a2 = TestUtils.serialised(a1);
         assertTrue(a1 == a2);
     }
 

--- a/src/test/java/org/jfree/data/time/TimePeriodValueTest.java
+++ b/src/test/java/org/jfree/data/time/TimePeriodValueTest.java
@@ -73,7 +73,7 @@ public class TimePeriodValueTest {
     @Test
     public void testSerialization() {
         TimePeriodValue tpv1 = new TimePeriodValue(new Day(30, 7, 2003), 55.75);
-        TimePeriodValue tpv2 = (TimePeriodValue) TestUtils.serialised(tpv1);
+        TimePeriodValue tpv2 = TestUtils.serialised(tpv1);
         assertEquals(tpv1, tpv2);
     }
 

--- a/src/test/java/org/jfree/data/time/TimePeriodValuesCollectionTest.java
+++ b/src/test/java/org/jfree/data/time/TimePeriodValuesCollectionTest.java
@@ -103,8 +103,7 @@ public class TimePeriodValuesCollectionTest {
     @Test
     public void testSerialization() {
         TimePeriodValuesCollection c1 = new TimePeriodValuesCollection();
-        TimePeriodValuesCollection c2 = (TimePeriodValuesCollection) 
-                TestUtils.serialised(c1);
+        TimePeriodValuesCollection c2 = TestUtils.serialised(c1);
         assertEquals(c1, c2);
     }
 

--- a/src/test/java/org/jfree/data/time/TimePeriodValuesTest.java
+++ b/src/test/java/org/jfree/data/time/TimePeriodValuesTest.java
@@ -134,7 +134,7 @@ public class TimePeriodValuesTest {
         s1.add(new Year(2002), null);
         s1.add(new Year(2005), 19.32);
         s1.add(new Year(2007), 16.89);
-        TimePeriodValues s2 = (TimePeriodValues) TestUtils.serialised(s1);
+        TimePeriodValues s2 = TestUtils.serialised(s1);
         assertTrue(s1.equals(s2));
     }
 

--- a/src/test/java/org/jfree/data/time/TimeSeriesCollectionTest.java
+++ b/src/test/java/org/jfree/data/time/TimeSeriesCollectionTest.java
@@ -222,8 +222,7 @@ public class TimeSeriesCollectionTest {
     @Test
     public void testSerialization() {
         TimeSeriesCollection c1 = new TimeSeriesCollection(createSeries());
-        TimeSeriesCollection c2 = (TimeSeriesCollection) 
-                TestUtils.serialised(c1);
+        TimeSeriesCollection c2 = TestUtils.serialised(c1);
         assertEquals(c1, c2);
     }
 

--- a/src/test/java/org/jfree/data/time/TimeSeriesDataItemTest.java
+++ b/src/test/java/org/jfree/data/time/TimeSeriesDataItemTest.java
@@ -85,8 +85,7 @@ public class TimeSeriesDataItemTest {
     public void testSerialization() {
         TimeSeriesDataItem item1 = new TimeSeriesDataItem(new Day(23, 9, 2001), 
                 99.7);
-        TimeSeriesDataItem item2 = (TimeSeriesDataItem) 
-                TestUtils.serialised(item1);
+        TimeSeriesDataItem item2 = TestUtils.serialised(item1);
         assertEquals(item1, item2);
     }
 

--- a/src/test/java/org/jfree/data/time/TimeSeriesTest.java
+++ b/src/test/java/org/jfree/data/time/TimeSeriesTest.java
@@ -264,7 +264,7 @@ public class TimeSeriesTest implements SeriesChangeListener {
         s1.add(new Year(2002), null);
         s1.add(new Year(2005), 19.32);
         s1.add(new Year(2007), 16.89);
-        TimeSeries s2 = (TimeSeries) TestUtils.serialised(s1);
+        TimeSeries s2 = TestUtils.serialised(s1);
         assertTrue(s1.equals(s2));
     }
 

--- a/src/test/java/org/jfree/data/time/TimeTableXYDatasetTest.java
+++ b/src/test/java/org/jfree/data/time/TimeTableXYDatasetTest.java
@@ -140,8 +140,7 @@ public class TimeTableXYDatasetTest {
     public void testSerialization() {
         TimeTableXYDataset d1 = new TimeTableXYDataset();
         d1.add(new Year(1999), 123.4, "S1");
-        TimeTableXYDataset d2 = (TimeTableXYDataset) 
-                TestUtils.serialised(d1);
+        TimeTableXYDataset d2 = TestUtils.serialised(d1);
         assertTrue(d1.equals(d2));
     }
 

--- a/src/test/java/org/jfree/data/time/WeekTest.java
+++ b/src/test/java/org/jfree/data/time/WeekTest.java
@@ -169,7 +169,7 @@ public class WeekTest {
     @Test
     public void testSerialization() {
         Week w1 = new Week(24, 1999);
-        Week w2 = (Week) TestUtils.serialised(w1);
+        Week w2 = TestUtils.serialised(w1);
         assertEquals(w1, w2);
     }
 

--- a/src/test/java/org/jfree/data/time/YearTest.java
+++ b/src/test/java/org/jfree/data/time/YearTest.java
@@ -286,7 +286,7 @@ public class YearTest {
     @Test
     public void testSerialization() {
         Year y1 = new Year(1999);
-        Year y2 = (Year) TestUtils.serialised(y1);
+        Year y2 = TestUtils.serialised(y1);
         assertEquals(y1, y2);
     }
 

--- a/src/test/java/org/jfree/data/time/ohlc/OHLCItemTest.java
+++ b/src/test/java/org/jfree/data/time/ohlc/OHLCItemTest.java
@@ -124,7 +124,7 @@ public class OHLCItemTest {
     @Test
     public void testSerialization() {
         OHLCItem item1 = new OHLCItem(new Year(2006), 2.0, 4.0, 1.0, 3.0);
-        OHLCItem item2 = (OHLCItem) TestUtils.serialised(item1);
+        OHLCItem item2 = TestUtils.serialised(item1);
         assertEquals(item1, item2);
     }
 

--- a/src/test/java/org/jfree/data/time/ohlc/OHLCSeriesCollectionTest.java
+++ b/src/test/java/org/jfree/data/time/ohlc/OHLCSeriesCollectionTest.java
@@ -115,8 +115,7 @@ public class OHLCSeriesCollectionTest implements DatasetChangeListener {
         OHLCSeries s1 = new OHLCSeries("Series");
         s1.add(new Year(2006), 1.0, 1.1, 1.2, 1.3);
         c1.addSeries(s1);
-        OHLCSeriesCollection c2 = (OHLCSeriesCollection) 
-                TestUtils.serialised(c1);
+        OHLCSeriesCollection c2 = TestUtils.serialised(c1);
         assertEquals(c1, c2);
     }
 

--- a/src/test/java/org/jfree/data/time/ohlc/OHLCSeriesTest.java
+++ b/src/test/java/org/jfree/data/time/ohlc/OHLCSeriesTest.java
@@ -136,7 +136,7 @@ public class OHLCSeriesTest implements SeriesChangeListener {
     public void testSerialization() {
         OHLCSeries s1 = new OHLCSeries("s1");
         s1.add(new Year(2006), 2.0, 4.0, 1.0, 3.0);
-        OHLCSeries s2 = (OHLCSeries) TestUtils.serialised(s1);
+        OHLCSeries s2 = TestUtils.serialised(s1);
         assertEquals(s1, s2);
     }
 

--- a/src/test/java/org/jfree/data/time/ohlc/OHLCTest.java
+++ b/src/test/java/org/jfree/data/time/ohlc/OHLCTest.java
@@ -93,7 +93,7 @@ public class OHLCTest {
     @Test
     public void testSerialization() {
         OHLC i1 = new OHLC(2.0, 4.0, 1.0, 3.0);
-        OHLC i2 = (OHLC) TestUtils.serialised(i1);
+        OHLC i2 = TestUtils.serialised(i1);
         assertEquals(i1, i2);
     }
 

--- a/src/test/java/org/jfree/data/xy/CategoryTableXYDatasetTest.java
+++ b/src/test/java/org/jfree/data/xy/CategoryTableXYDatasetTest.java
@@ -142,8 +142,7 @@ public class CategoryTableXYDatasetTest {
         CategoryTableXYDataset d1 = new CategoryTableXYDataset();
         d1.add(1.0, 1.1, "Series 1");
         d1.add(2.0, 2.2, "Series 1");
-        CategoryTableXYDataset d2 = (CategoryTableXYDataset) 
-                TestUtils.serialised(d1);
+        CategoryTableXYDataset d2 = TestUtils.serialised(d1);
         assertEquals(d1, d2);
     }
 

--- a/src/test/java/org/jfree/data/xy/DefaultHighLowDatasetTest.java
+++ b/src/test/java/org/jfree/data/xy/DefaultHighLowDatasetTest.java
@@ -174,8 +174,7 @@ public class DefaultHighLowDatasetTest {
                 new Date[] {new Date(123L)}, new double[] {1.2},
                 new double[] {3.4}, new double[] {5.6}, new double[] {7.8},
                 new double[] {99.9});
-        DefaultHighLowDataset d2 = (DefaultHighLowDataset) 
-                TestUtils.serialised(d1);
+        DefaultHighLowDataset d2 = TestUtils.serialised(d1);
         assertEquals(d1, d2);
     }
 

--- a/src/test/java/org/jfree/data/xy/DefaultIntervalXYDatasetTest.java
+++ b/src/test/java/org/jfree/data/xy/DefaultIntervalXYDatasetTest.java
@@ -271,13 +271,12 @@ public class DefaultIntervalXYDatasetTest {
     @Test
     public void testSerialization() {
         DefaultIntervalXYDataset d1 = new DefaultIntervalXYDataset();
-        DefaultIntervalXYDataset d2 = (DefaultIntervalXYDataset) 
-                TestUtils.serialised(d1);
+        DefaultIntervalXYDataset d2 = TestUtils.serialised(d1);
         assertEquals(d1, d2);
 
         // try a dataset with some content...
         d1 = createSampleDataset1();
-        d2 = (DefaultIntervalXYDataset) TestUtils.serialised(d1);
+        d2 = TestUtils.serialised(d1);
         assertEquals(d1, d2);
     }
 

--- a/src/test/java/org/jfree/data/xy/DefaultOHLCDatasetTest.java
+++ b/src/test/java/org/jfree/data/xy/DefaultOHLCDatasetTest.java
@@ -148,7 +148,7 @@ public class DefaultOHLCDatasetTest {
     public void testSerialization() {
         DefaultOHLCDataset d1 = new DefaultOHLCDataset("Series 1",
                 new OHLCDataItem[0]);
-        DefaultOHLCDataset d2 = (DefaultOHLCDataset) TestUtils.serialised(d1);
+        DefaultOHLCDataset d2 = TestUtils.serialised(d1);
         assertEquals(d1, d2);
     }
 

--- a/src/test/java/org/jfree/data/xy/DefaultTableXYDatasetTest.java
+++ b/src/test/java/org/jfree/data/xy/DefaultTableXYDatasetTest.java
@@ -118,8 +118,7 @@ public class DefaultTableXYDatasetTest {
         s1.add(2.0, 2.2);
         d1.addSeries(s1);
 
-        DefaultTableXYDataset d2 = (DefaultTableXYDataset) 
-                TestUtils.serialised(d1);
+        DefaultTableXYDataset d2 = TestUtils.serialised(d1);
         assertEquals(d1, d2);
     }
 

--- a/src/test/java/org/jfree/data/xy/DefaultWindDatasetTest.java
+++ b/src/test/java/org/jfree/data/xy/DefaultWindDatasetTest.java
@@ -103,12 +103,12 @@ public class DefaultWindDatasetTest {
     @Test
     public void testSerialization() {
         DefaultWindDataset d1 = new DefaultWindDataset();
-        DefaultWindDataset d2 = (DefaultWindDataset) TestUtils.serialised(d1);
+        DefaultWindDataset d2 = TestUtils.serialised(d1);
         assertEquals(d1, d2);
 
         // try a dataset with some content...
         d1 = createSampleDataset1();
-        d2 = (DefaultWindDataset) TestUtils.serialised(d1);
+        d2 = TestUtils.serialised(d1);
         assertEquals(d1, d2);
     }
 

--- a/src/test/java/org/jfree/data/xy/DefaultXYDatasetTest.java
+++ b/src/test/java/org/jfree/data/xy/DefaultXYDatasetTest.java
@@ -117,7 +117,7 @@ public class DefaultXYDatasetTest {
     public void testSerialization() {
 
         DefaultXYDataset d1 = new DefaultXYDataset();
-        DefaultXYDataset d2 = (DefaultXYDataset) TestUtils.serialised(d1);
+        DefaultXYDataset d2 = TestUtils.serialised(d1);
         assertEquals(d1, d2);
 
         // try a dataset with some content...
@@ -125,7 +125,7 @@ public class DefaultXYDatasetTest {
         double[] y1 = new double[] {4.0, 5.0, 6.0};
         double[][] data1 = new double[][] {x1, y1};
         d1.addSeries("S1", data1);
-        d2 = (DefaultXYDataset) TestUtils.serialised(d1);
+        d2 = TestUtils.serialised(d1);
         assertEquals(d1, d2);
     }
 

--- a/src/test/java/org/jfree/data/xy/DefaultXYZDatasetTest.java
+++ b/src/test/java/org/jfree/data/xy/DefaultXYZDatasetTest.java
@@ -119,7 +119,7 @@ public class DefaultXYZDatasetTest {
     @Test
     public void testSerialization() {
         DefaultXYZDataset d1 = new DefaultXYZDataset();
-        DefaultXYZDataset d2 = (DefaultXYZDataset) TestUtils.serialised(d1);
+        DefaultXYZDataset d2 = TestUtils.serialised(d1);
         assertEquals(d1, d2);
 
         // try a dataset with some content...
@@ -128,7 +128,7 @@ public class DefaultXYZDatasetTest {
         double[] z1 = new double[] {7.0, 8.0, 9.0};
         double[][] data1 = new double[][] {x1, y1, z1};
         d1.addSeries("S1", data1);
-        d2 = (DefaultXYZDataset) TestUtils.serialised(d1);
+        d2 = TestUtils.serialised(d1);
         assertEquals(d1, d2);
     }
 

--- a/src/test/java/org/jfree/data/xy/IntervalXYDelegateTest.java
+++ b/src/test/java/org/jfree/data/xy/IntervalXYDelegateTest.java
@@ -110,7 +110,7 @@ public class IntervalXYDelegateTest {
         XYSeriesCollection c1 = new XYSeriesCollection();
         c1.addSeries(s1);
         IntervalXYDelegate d1 = new IntervalXYDelegate(c1);
-        IntervalXYDelegate d2 = (IntervalXYDelegate) TestUtils.serialised(d1);
+        IntervalXYDelegate d2 = TestUtils.serialised(d1);
         assertEquals(d1, d2);
     }
 

--- a/src/test/java/org/jfree/data/xy/MatrixSeriesCollectionTest.java
+++ b/src/test/java/org/jfree/data/xy/MatrixSeriesCollectionTest.java
@@ -111,8 +111,7 @@ public class MatrixSeriesCollectionTest {
         s1.update(0, 0, 1.1);
         MatrixSeriesCollection c1 = new MatrixSeriesCollection();
         c1.addSeries(s1);
-        MatrixSeriesCollection c2 = (MatrixSeriesCollection) 
-                TestUtils.serialised(c1);
+        MatrixSeriesCollection c2 = TestUtils.serialised(c1);
         assertEquals(c1, c2);
     }
 

--- a/src/test/java/org/jfree/data/xy/MatrixSeriesTest.java
+++ b/src/test/java/org/jfree/data/xy/MatrixSeriesTest.java
@@ -106,7 +106,7 @@ public class MatrixSeriesTest {
         MatrixSeries m1 = new MatrixSeries("Test", 8, 3);
         m1.update(0, 0, 11.0);
         m1.update(7, 2, 22.0);
-        MatrixSeries m2 = (MatrixSeries) TestUtils.serialised(m1);
+        MatrixSeries m2 = TestUtils.serialised(m1);
         assertEquals(m1, m2);
     }
 

--- a/src/test/java/org/jfree/data/xy/OHLCDataItemTest.java
+++ b/src/test/java/org/jfree/data/xy/OHLCDataItemTest.java
@@ -81,7 +81,7 @@ public class OHLCDataItemTest {
     public void testSerialization() {
         OHLCDataItem i1 = new OHLCDataItem(new Date(1L), 1.0, 2.0, 3.0, 4.0, 
                 5.0);
-        OHLCDataItem i2 = (OHLCDataItem) TestUtils.serialised(i1);
+        OHLCDataItem i2 = TestUtils.serialised(i1);
         assertEquals(i1, i2);
     }
 

--- a/src/test/java/org/jfree/data/xy/TableXYDatasetTest.java
+++ b/src/test/java/org/jfree/data/xy/TableXYDatasetTest.java
@@ -98,8 +98,7 @@ public class TableXYDatasetTest {
     public void testSerialization() {
         DefaultTableXYDataset d1 = new DefaultTableXYDataset();
         d1.addSeries(createSeries2());
-        DefaultTableXYDataset d2 = (DefaultTableXYDataset) 
-                TestUtils.serialised(d1);
+        DefaultTableXYDataset d2 = TestUtils.serialised(d1);
         assertEquals(d1, d2);
     }
 

--- a/src/test/java/org/jfree/data/xy/VectorDataItemTest.java
+++ b/src/test/java/org/jfree/data/xy/VectorDataItemTest.java
@@ -111,7 +111,7 @@ public class VectorDataItemTest {
     @Test
     public void testSerialization() {
         VectorDataItem v1 = new VectorDataItem(1.0, 2.0, 3.0, 4.0);
-        VectorDataItem v2 = (VectorDataItem) TestUtils.serialised(v1);
+        VectorDataItem v2 = TestUtils.serialised(v1);
         assertEquals(v1, v2);
     }
 

--- a/src/test/java/org/jfree/data/xy/VectorSeriesCollectionTest.java
+++ b/src/test/java/org/jfree/data/xy/VectorSeriesCollectionTest.java
@@ -110,8 +110,7 @@ public class VectorSeriesCollectionTest {
         s1.add(1.0, 1.1, 1.2, 1.3);
         VectorSeriesCollection c1 = new VectorSeriesCollection();
         c1.addSeries(s1);
-        VectorSeriesCollection c2 = (VectorSeriesCollection) 
-                TestUtils.serialised(c1);
+        VectorSeriesCollection c2 = TestUtils.serialised(c1);
         assertEquals(c1, c2);
     }
 

--- a/src/test/java/org/jfree/data/xy/VectorSeriesTest.java
+++ b/src/test/java/org/jfree/data/xy/VectorSeriesTest.java
@@ -135,7 +135,7 @@ public class VectorSeriesTest implements SeriesChangeListener {
     public void testSerialization() {
         VectorSeries s1 = new VectorSeries("s1");
         s1.add(1.0, 0.5, 1.5, 2.0);
-        VectorSeries s2 = (VectorSeries) TestUtils.serialised(s1);
+        VectorSeries s2 = TestUtils.serialised(s1);
         assertEquals(s1, s2);
     }
 

--- a/src/test/java/org/jfree/data/xy/VectorTest.java
+++ b/src/test/java/org/jfree/data/xy/VectorTest.java
@@ -98,7 +98,7 @@ public class VectorTest {
     @Test
     public void testSerialization() {
         Vector v1 = new Vector(1.0, 2.0);
-        Vector v2 = (Vector) TestUtils.serialised(v1);
+        Vector v2 = TestUtils.serialised(v1);
         assertEquals(v1, v2);
     }
 

--- a/src/test/java/org/jfree/data/xy/XIntervalDataItemTest.java
+++ b/src/test/java/org/jfree/data/xy/XIntervalDataItemTest.java
@@ -118,7 +118,7 @@ public class XIntervalDataItemTest {
     @Test
     public void testSerialization() {
         XIntervalDataItem item1 = new XIntervalDataItem(1.0, 2.0, 3.0, 4.0);
-        XIntervalDataItem item2 = (XIntervalDataItem) TestUtils.serialised(item1);
+        XIntervalDataItem item2 = TestUtils.serialised(item1);
         assertEquals(item1, item2);
     }
 

--- a/src/test/java/org/jfree/data/xy/XIntervalSeriesCollectionTest.java
+++ b/src/test/java/org/jfree/data/xy/XIntervalSeriesCollectionTest.java
@@ -112,8 +112,7 @@ public class XIntervalSeriesCollectionTest {
         XIntervalSeriesCollection c1 = new XIntervalSeriesCollection();
         XIntervalSeries s1 = new XIntervalSeries("Series");
         s1.add(1.0, 1.1, 1.2, 1.3);
-        XIntervalSeriesCollection c2 = (XIntervalSeriesCollection) 
-                TestUtils.serialised(c1);
+        XIntervalSeriesCollection c2 = TestUtils.serialised(c1);
         assertEquals(c1, c2);
     }
 

--- a/src/test/java/org/jfree/data/xy/XIntervalSeriesTest.java
+++ b/src/test/java/org/jfree/data/xy/XIntervalSeriesTest.java
@@ -133,7 +133,7 @@ public class XIntervalSeriesTest implements SeriesChangeListener {
     public void testSerialization()  {
         XIntervalSeries s1 = new XIntervalSeries("s1");
         s1.add(1.0, 0.5, 1.5, 2.0);
-        XIntervalSeries s2 = (XIntervalSeries) TestUtils.serialised(s1);
+        XIntervalSeries s2 = TestUtils.serialised(s1);
         assertEquals(s1, s2);
     }
 

--- a/src/test/java/org/jfree/data/xy/XYBarDatasetTest.java
+++ b/src/test/java/org/jfree/data/xy/XYBarDatasetTest.java
@@ -122,7 +122,7 @@ public class XYBarDatasetTest {
         double[][] data1 = new double[][] {x1, y1};
         d1.addSeries("S1", data1);
         XYBarDataset bd1 = new XYBarDataset(d1, 5.0);
-        XYBarDataset bd2 = (XYBarDataset) TestUtils.serialised(bd1);
+        XYBarDataset bd2 = TestUtils.serialised(bd1);
         assertEquals(bd1, bd2);
     }
 

--- a/src/test/java/org/jfree/data/xy/XYCoordinateTest.java
+++ b/src/test/java/org/jfree/data/xy/XYCoordinateTest.java
@@ -98,7 +98,7 @@ public class XYCoordinateTest {
     @Test
     public void testSerialization() {
         XYCoordinate v1 = new XYCoordinate(1.0, 2.0);
-        XYCoordinate v2 = (XYCoordinate) TestUtils.serialised(v1);
+        XYCoordinate v2 = TestUtils.serialised(v1);
         assertEquals(v1, v2);
     }
 

--- a/src/test/java/org/jfree/data/xy/XYDataItemTest.java
+++ b/src/test/java/org/jfree/data/xy/XYDataItemTest.java
@@ -83,7 +83,7 @@ public class XYDataItemTest {
     @Test
     public void testSerialization() {
         XYDataItem i1 = new XYDataItem(1.0, 1.1);
-        XYDataItem i2 = (XYDataItem) TestUtils.serialised(i1);
+        XYDataItem i2 = TestUtils.serialised(i1);
         assertEquals(i1, i2);
     }
 

--- a/src/test/java/org/jfree/data/xy/XYIntervalDataItemTest.java
+++ b/src/test/java/org/jfree/data/xy/XYIntervalDataItemTest.java
@@ -135,8 +135,7 @@ public class XYIntervalDataItemTest {
     public void testSerialization() {
         XYIntervalDataItem item1 = new XYIntervalDataItem(1.0, 0.5, 1.5, 2.0,
                 1.9, 2.1);
-        XYIntervalDataItem item2 = (XYIntervalDataItem) 
-                TestUtils.serialised(item1);
+        XYIntervalDataItem item2 = TestUtils.serialised(item1);
         assertEquals(item1, item2);
     }
 

--- a/src/test/java/org/jfree/data/xy/XYIntervalSeriesCollectionTest.java
+++ b/src/test/java/org/jfree/data/xy/XYIntervalSeriesCollectionTest.java
@@ -113,8 +113,7 @@ public class XYIntervalSeriesCollectionTest {
         XYIntervalSeriesCollection c1 = new XYIntervalSeriesCollection();
         XYIntervalSeries s1 = new XYIntervalSeries("Series");
         s1.add(1.0, 1.1, 1.2, 1.3, 1.4, 1.5);
-        XYIntervalSeriesCollection c2 = (XYIntervalSeriesCollection) 
-                TestUtils.serialised(c1);
+        XYIntervalSeriesCollection c2 = TestUtils.serialised(c1);
         assertEquals(c1, c2);
 
         // check independence

--- a/src/test/java/org/jfree/data/xy/XYIntervalSeriesTest.java
+++ b/src/test/java/org/jfree/data/xy/XYIntervalSeriesTest.java
@@ -132,7 +132,7 @@ public class XYIntervalSeriesTest implements SeriesChangeListener {
     public void testSerialization() {
         XYIntervalSeries s1 = new XYIntervalSeries("s1");
         s1.add(1.0, 0.5, 1.5, 2.0, 1.9, 2.1);
-        XYIntervalSeries s2 = (XYIntervalSeries) TestUtils.serialised(s1);
+        XYIntervalSeries s2 = TestUtils.serialised(s1);
         assertEquals(s1, s2);
     }
 

--- a/src/test/java/org/jfree/data/xy/XYIntervalTest.java
+++ b/src/test/java/org/jfree/data/xy/XYIntervalTest.java
@@ -98,7 +98,7 @@ public class XYIntervalTest {
     @Test
     public void testSerialization() {
         XYInterval i1 = new XYInterval(1.0, 2.0, 3.0, 2.5, 3.5);
-        XYInterval i2 = (XYInterval) TestUtils.serialised(i1);
+        XYInterval i2 = TestUtils.serialised(i1);
         assertEquals(i1, i2);
     }
 

--- a/src/test/java/org/jfree/data/xy/XYSeriesCollectionTest.java
+++ b/src/test/java/org/jfree/data/xy/XYSeriesCollectionTest.java
@@ -144,8 +144,7 @@ public class XYSeriesCollectionTest {
         s1.add(1.0, 1.1);
         XYSeriesCollection c1 = new XYSeriesCollection();
         c1.addSeries(s1);
-        XYSeriesCollection c2 = (XYSeriesCollection) 
-                TestUtils.serialised(c1);
+        XYSeriesCollection c2 = TestUtils.serialised(c1);
         assertEquals(c1, c2);
     }
 

--- a/src/test/java/org/jfree/data/xy/XYSeriesTest.java
+++ b/src/test/java/org/jfree/data/xy/XYSeriesTest.java
@@ -163,7 +163,7 @@ public class XYSeriesTest {
     public void testSerialization() {
         XYSeries s1 = new XYSeries("Series");
         s1.add(1.0, 1.1);
-        XYSeries s2 = (XYSeries) TestUtils.serialised(s1);
+        XYSeries s2 = TestUtils.serialised(s1);
         assertEquals(s1, s2);
     }
 

--- a/src/test/java/org/jfree/data/xy/YIntervalDataItemTest.java
+++ b/src/test/java/org/jfree/data/xy/YIntervalDataItemTest.java
@@ -116,8 +116,7 @@ public class YIntervalDataItemTest {
     @Test
     public void testSerialization() {
         YIntervalDataItem item1 = new YIntervalDataItem(1.0, 2.0, 1.5, 2.5);
-        YIntervalDataItem item2 = (YIntervalDataItem) 
-                TestUtils.serialised(item1);
+        YIntervalDataItem item2 = TestUtils.serialised(item1);
         assertEquals(item1, item2);
     }
 

--- a/src/test/java/org/jfree/data/xy/YIntervalSeriesCollectionTest.java
+++ b/src/test/java/org/jfree/data/xy/YIntervalSeriesCollectionTest.java
@@ -112,8 +112,7 @@ public class YIntervalSeriesCollectionTest {
         YIntervalSeriesCollection c1 = new YIntervalSeriesCollection();
         YIntervalSeries s1 = new YIntervalSeries("Series");
         s1.add(1.0, 1.1, 1.2, 1.3);
-        YIntervalSeriesCollection c2 = (YIntervalSeriesCollection) 
-                TestUtils.serialised(c1);
+        YIntervalSeriesCollection c2 = TestUtils.serialised(c1);
         assertEquals(c1, c2);
     }
 

--- a/src/test/java/org/jfree/data/xy/YIntervalSeriesTest.java
+++ b/src/test/java/org/jfree/data/xy/YIntervalSeriesTest.java
@@ -133,7 +133,7 @@ public class YIntervalSeriesTest implements SeriesChangeListener {
     public void testSerialization() {
         YIntervalSeries s1 = new YIntervalSeries("s1");
         s1.add(1.0, 0.5, 1.5, 2.0);
-        YIntervalSeries s2 = (YIntervalSeries) TestUtils.serialised(s1);
+        YIntervalSeries s2 = TestUtils.serialised(s1);
         assertEquals(s1, s2);
     }
 

--- a/src/test/java/org/jfree/data/xy/YIntervalTest.java
+++ b/src/test/java/org/jfree/data/xy/YIntervalTest.java
@@ -88,7 +88,7 @@ public class YIntervalTest {
     @Test
     public void testSerialization() {
         YInterval i1 = new YInterval(1.0, 0.5, 1.5);
-        YInterval i2 = (YInterval) TestUtils.serialised(i1);
+        YInterval i2 = TestUtils.serialised(i1);
         assertEquals(i1, i2);
     }
 

--- a/src/test/java/org/jfree/data/xy/YWithXIntervalTest.java
+++ b/src/test/java/org/jfree/data/xy/YWithXIntervalTest.java
@@ -88,7 +88,7 @@ public class YWithXIntervalTest {
     @Test
     public void testSerialization() {
         YWithXInterval i1 = new YWithXInterval(1.0, 0.5, 1.5);
-        YWithXInterval i2 = (YWithXInterval) TestUtils.serialised(i1);
+        YWithXInterval i2 = TestUtils.serialised(i1);
         assertEquals(i1, i2);
     }
 


### PR DESCRIPTION
Fixed all the warnings regarding casting when calling TestUtils.serialised