### PR TITLE
Backport issue #216.

### DIFF
--- a/src/main/java/org/jfree/data/general/DefaultPieDataset.java
+++ b/src/main/java/org/jfree/data/general/DefaultPieDataset.java
@@ -75,7 +75,7 @@ public class DefaultPieDataset<K extends Comparable<K>> extends AbstractDataset
      * @param source  the data ({@code null} not permitted).
      */
     public DefaultPieDataset(KeyedValues<K> source) {
-        Args.nullNotPermitted(data, "data");
+        Args.nullNotPermitted(source, "source");
         this.data = new DefaultKeyedValues<>();
         for (int i = 0; i < source.getItemCount(); i++) {
             this.data.addValue(source.getKey(i), source.getValue(i));


### PR DESCRIPTION
Backport of fix for wrong null check in `DefaultPieDataset(KeyedValues<K> source)` #216, raised in issue #264.