### PR TITLE
Typo in the AbstractBlockTest Class

### DIFF
--- a/src/test/java/org/jfree/chart/block/AbstractBlockTest.java
+++ b/src/test/java/org/jfree/chart/block/AbstractBlockTest.java
@@ -49,7 +49,7 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * Tests for the {@link AbstractBlock} class.
  */
-public class AbstractBlockTest{
+public class AbstractBlockTest {
 
     /**
      * Confirm that the equals() method can distinguish all the required fields.


### PR DESCRIPTION
I fixed a typo in the class Name of AbstractBlockTest {