### PR TITLE
Set `javac`'s release option to 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.release.level>11</project.release.level>
         <project.source.level>11</project.source.level>
         <project.target.level>11</project.target.level>
     </properties>
@@ -93,6 +94,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
+                    <release>${project.release.level}</release>
                     <source>${project.source.level}</source>
                     <target>${project.target.level}</target>
                     <encoding>${project.build.sourceEncoding}</encoding>                


### PR DESCRIPTION
This setting eliminates the following warning emitted by Maven in main and test compile phases:

```console
[WARNING] system modules path not set in conjunction with -source 11
```

For running `mvn`, the `source` and `target` properties could also be removed -- but iirc, then IDE(A)s might not detect the required Java version anymore.