### PR TITLE
Clone data item instead of creating new one to preserve class inheritance.

### DIFF
--- a/src/main/java/org/jfree/data/time/TimeSeries.java
+++ b/src/main/java/org/jfree/data/time/TimeSeries.java
@@ -725,8 +725,7 @@ public class TimeSeries<S extends Comparable<S>> extends Series<S>
         TimeSeries<S> overwritten = new TimeSeries<>(getKey());
         for (int i = 0; i < series.getItemCount(); i++) {
             TimeSeriesDataItem item = series.getRawDataItem(i);
-            TimeSeriesDataItem oldItem = addOrUpdate(item.getPeriod(),
-                    item.getValue());
+            TimeSeriesDataItem oldItem = addOrUpdate(item.clone());
             if (oldItem != null) {
                 overwritten.add(oldItem);
             }


### PR DESCRIPTION
To store a bit more data we extend `TimeSeriesDataItem` class, but on calling `TimeSeries.addAndOrUpdate()` we lose inheritance.