### PR TITLE
configuration properties package with tests

### DIFF
--- a/src/main/java/org/jfree/chart/swing/configuration/DefaultAxisConfiguration.java
+++ b/src/main/java/org/jfree/chart/swing/configuration/DefaultAxisConfiguration.java
@@ -1,0 +1,185 @@
+/* ===========================================================
+ * JFreeChart : a free chart library for the Java(tm) platform
+ * ===========================================================
+ *
+ * (C) Copyright 2000-2022, by David Gilbert and Contributors.
+ *
+ * Project Info:  http://www.jfree.org/jfreechart/index.html
+ *
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ * [Oracle and Java are registered trademarks of Oracle and/or its affiliates.
+ * Other names may be trademarks of their respective owners.]
+ *
+ * ----------------------
+ * DefaultAxisConfiguration.java
+ * ----------------------
+ * (C) Copyright 2005-2022, by David Gilbert and Contributors.
+ *
+ * Original Author:  David Gilbert;
+ * Contributor(s):   Andrzej Porebski;
+ *                   Arnaud Lelievre;
+ *                   Dimitry Polivaev
+ *
+ */
+
+package org.jfree.chart.swing.configuration;
+
+import java.awt.Color;
+import java.awt.Font;
+import java.util.Properties;
+
+import org.jfree.chart.axis.Axis;
+import org.jfree.chart.axis.LogAxis;
+import org.jfree.chart.axis.NumberAxis;
+
+/**
+ * A panel for editing the properties of an axis.
+ */
+class DefaultAxisConfiguration {
+
+
+    public static boolean isContainedIn(Properties properties, String name) {
+        return properties.getProperty(name + "." + "areTickLabelsVisible") != null;
+    }
+    protected final String name;
+
+    private final String label;
+
+    private Font labelFont;
+
+    private final Color labelColor;
+
+    private Font tickLabelFont;
+
+
+    private final Color tickLabelColor;
+
+    private final boolean areTickLabelsVisible;
+
+    private final boolean areTickMarksVisible;
+
+
+    private final RectangleInsetsConfiguration tickLabelInsets;
+
+    private final RectangleInsetsConfiguration labelInsets;
+
+    /**
+     * A static method that returns a configuration that is appropriate for the axis
+     * type.
+     *
+     * @param axis  the axis whose properties are to be displayed/edited in
+     *              the panel.
+     *
+     * @return A panel or {@code null} if axis is {@code null}.
+     */
+    static DefaultAxisConfiguration getInstance(Axis axis, String name) {
+
+        if (axis != null) {
+            // figure out what type of axis we have and instantiate the
+            // appropriate panel
+            if (axis instanceof NumberAxis) {
+                return new DefaultNumberAxisConfiguration((NumberAxis) axis, name);
+            }
+            if (axis instanceof LogAxis) {
+                return new DefaultLogAxisConfiguration((LogAxis) axis, name);
+            }
+            else {
+                return new DefaultAxisConfiguration(axis, name);
+            }
+        }
+        else {
+            return null;
+        }
+
+    }
+
+    public static DefaultAxisConfiguration getInstance(Properties properties, String name) {
+        if(DefaultNumberAxisConfiguration.isContainedIn(properties, name))
+            return new DefaultNumberAxisConfiguration(properties, name);
+        if(DefaultLogAxisConfiguration.isContainedIn(properties, name))
+            return new DefaultLogAxisConfiguration(properties, name);
+        if(DefaultValueAxisConfiguration.isContainedIn(properties, name))
+            return new DefaultValueAxisConfiguration(properties, name);
+        if(DefaultAxisConfiguration.isContainedIn(properties, name))
+            return new DefaultAxisConfiguration(properties, name);
+        return null;
+
+    }
+
+
+    /**
+     * Standard constructor: builds a panel for displaying/editing the
+     * properties of the specified axis.
+     *
+     * @param axis  the axis whose properties are to be displayed/edited in
+     *              the panel.
+     */
+    DefaultAxisConfiguration(Axis axis, String name) {
+        this.name = name;
+        this.label = axis.getLabel();
+        this.labelFont = axis.getLabelFont();
+        this.labelColor = (Color) axis.getLabelPaint();
+        this.tickLabelFont = axis.getTickLabelFont();
+        this.tickLabelColor = (Color) axis.getTickLabelPaint();
+
+        // Insets values
+        this.tickLabelInsets = new RectangleInsetsConfiguration(axis.getTickLabelInsets(), name + "." + "tickLabelInsets");
+        this.labelInsets = new RectangleInsetsConfiguration(axis.getLabelInsets(), name + "." + "labelInsets");
+
+        this.areTickLabelsVisible =axis.isTickLabelsVisible();
+        this.areTickMarksVisible =axis.isTickMarksVisible();
+    }
+
+
+    DefaultAxisConfiguration(Properties properties, String name) {
+        this.name = name;
+        this.label = properties.getProperty(name + "." + "label");
+        this.labelFont = StringMapper.stringToFont(properties.getProperty(name + "." + "labelFont"));
+        this.labelColor = StringMapper.stringToColor(properties.getProperty(name + "." + "labelColor"));
+        this.tickLabelFont = StringMapper.stringToFont(properties.getProperty(name + "." + "tickLabelFont"));
+        this.tickLabelColor = StringMapper.stringToColor(properties.getProperty(name + "." + "tickLabelColor"));
+        this.tickLabelInsets = new RectangleInsetsConfiguration(properties, name + "." + "tickLabelInsets");
+        this.labelInsets = new RectangleInsetsConfiguration(properties, name + "." + "labelInsets");
+        this.areTickLabelsVisible = Boolean.valueOf(properties.getProperty(name + "." + "areTickLabelsVisible"));
+        this.areTickMarksVisible = Boolean.valueOf(properties.getProperty(name + "." + "areTickMarksVisible"));
+    }
+
+    void fillProperties(Properties properties) {
+        if(label != null)
+            properties.setProperty(name + "." + "label", label);
+        properties.setProperty(name + "." + "labelFont", StringMapper.fontToString(labelFont));
+        properties.setProperty(name + "." + "labelColor", StringMapper.colorToString(labelColor));
+        properties.setProperty(name + "." + "tickLabelFont", StringMapper.fontToString(tickLabelFont));
+        properties.setProperty(name + "." + "tickLabelColor", StringMapper.colorToString(tickLabelColor));
+        tickLabelInsets.fillProperties(properties);
+        labelInsets.fillProperties(properties);
+        properties.setProperty(name + "." + "areTickLabelsVisible", Boolean.toString(areTickLabelsVisible));
+        properties.setProperty(name + "." + "areTickMarksVisible", Boolean.toString(areTickMarksVisible));
+    }
+
+    void setAxisProperties(Axis axis) {
+        axis.setLabel(label);
+        axis.setLabelFont(labelFont);
+        axis.setLabelPaint(labelColor);
+        axis.setTickMarksVisible(areTickMarksVisible);
+        axis.setTickLabelsVisible(areTickLabelsVisible);
+        axis.setTickLabelFont(tickLabelFont);
+        axis.setTickLabelPaint(tickLabelColor);
+        axis.setTickLabelInsets(tickLabelInsets.getRectangleInsets());
+        axis.setLabelInsets(labelInsets.getRectangleInsets());
+    }
+}

--- a/src/main/java/org/jfree/chart/swing/configuration/DefaultChartConfiguration.java
+++ b/src/main/java/org/jfree/chart/swing/configuration/DefaultChartConfiguration.java
@@ -1,0 +1,114 @@
+/* ===========================================================
+ * JFreeChart : a free chart library for the Java(tm) platform
+ * ===========================================================
+ *
+ * (C) Copyright 2000-2022, by David Gilbert and Contributors.
+ *
+ * Project Info:  http://www.jfree.org/jfreechart/index.html
+ *
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ * [Oracle and Java are registered trademarks of Oracle and/or its affiliates.
+ * Other names may be trademarks of their respective owners.]
+ *
+ * -----------------------
+ * DefaultChartConfiguration.java
+ * -----------------------
+ * (C) Copyright 2000-2022, by David Gilbert.
+ *
+ * Original Author:  David Gilbert;
+ * Contributor(s):   Arnaud Lelievre;
+ *                   Daniel Gredler;
+ *                   Dimitry Polivaev
+*
+ */
+
+package org.jfree.chart.swing.configuration;
+
+import java.awt.Color;
+import java.util.Properties;
+
+import org.jfree.chart.JFreeChart;
+import org.jfree.chart.plot.Plot;
+import org.jfree.chart.plot.PolarPlot;
+import org.jfree.chart.title.Title;
+
+/**
+ * A panel for editing chart properties (includes subpanels for the title,
+ * legend and plot).
+ */
+public class DefaultChartConfiguration {
+
+    private final DefaultTitleConfiguration titleConfiguration;
+
+    private final DefaultPlotConfiguration plotConfiguration;
+
+    private final boolean antialias;
+
+    private final Color background;
+
+    DefaultChartConfiguration(JFreeChart chart) {
+        this.antialias = chart.getAntiAlias();
+        this.background = (Color) chart.getBackgroundPaint();
+
+        Title title = chart.getTitle();
+        Plot plot = chart.getPlot();
+        this.titleConfiguration = new DefaultTitleConfiguration(title, "title");
+        if (plot instanceof PolarPlot) {
+            this.plotConfiguration = new DefaultPolarPlotConfiguration((PolarPlot) plot, "plot");
+        }
+        else {
+            this.plotConfiguration = new DefaultPlotConfiguration(plot, "plot");
+        }
+    }
+
+
+    DefaultChartConfiguration(Properties properties) {
+        antialias = Boolean.parseBoolean(properties.getProperty("antialias", "true"));
+        String x = properties.getProperty("background");
+        background = StringMapper.stringToColor(x);
+        this.titleConfiguration = new DefaultTitleConfiguration(properties, "title");
+        if(Boolean.valueOf(properties.getProperty("polarPlot"))) {
+                this.plotConfiguration = new DefaultPolarPlotConfiguration(properties, "plot");
+            }
+            else {
+                this.plotConfiguration = new DefaultPlotConfiguration(properties, "plot");
+            }
+    }
+
+
+    void fillProperties(Properties properties) {
+        properties.setProperty("antialias", Boolean.toString(antialias));
+        properties.setProperty("background", StringMapper.colorToString(background));
+        properties.setProperty("polarPlot", Boolean.toString(plotConfiguration instanceof DefaultPolarPlotConfiguration));
+        titleConfiguration.fillProperties(properties);
+        plotConfiguration.fillProperties(properties);
+    }
+
+    public void updateChart(JFreeChart chart) {
+        this.titleConfiguration.setTitleProperties(chart);
+        this.plotConfiguration.updatePlotProperties(chart.getPlot());
+        chart.setAntiAlias(antialias);
+        chart.setBackgroundPaint(background);
+    }
+
+    public Properties getProperties() {
+        Properties properties = new Properties();
+        fillProperties(properties);
+        return properties;
+    }
+
+}

--- a/src/main/java/org/jfree/chart/swing/configuration/DefaultLogAxisConfiguration.java
+++ b/src/main/java/org/jfree/chart/swing/configuration/DefaultLogAxisConfiguration.java
@@ -1,0 +1,88 @@
+/* ===========================================================
+ * JFreeChart : a free chart library for the Java(tm) platform
+ * ===========================================================
+ *
+ * (C) Copyright 2000-2022, by David Gilbert and Contributors.
+ *
+ * Project Info:  http://www.jfree.org/jfreechart/index.html
+ *
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ * [Oracle and Java are registered trademarks of Oracle and/or its affiliates.
+ * Other names may be trademarks of their respective owners.]
+ *
+ * -------------------------
+ * DefaultLogAxisConfiguration.java
+ * -------------------------
+ * (C) Copyright 2005-2022, by David Gilbert and Contributors.
+ *
+ * Original Author:  Martin Hoeller;
+ * Contributor(s):   Dimitry Polivaev;
+ *
+ */
+
+package org.jfree.chart.swing.configuration;
+
+import java.util.Properties;
+
+import org.jfree.chart.axis.Axis;
+import org.jfree.chart.axis.LogAxis;
+import org.jfree.chart.axis.NumberTickUnit;
+
+/**
+ * A panel for editing properties of a {@link LogAxis}.
+ */
+class DefaultLogAxisConfiguration extends DefaultValueAxisConfiguration {
+
+    private static final String MANUAL_TICK_UNIT = "logAxisManualTickUnit";
+
+    public static boolean isContainedIn(Properties properties, String name) {
+        return properties.getProperty(name + "." + MANUAL_TICK_UNIT) != null;
+    }
+
+
+    private final double manualTickUnit;
+
+    /**
+     * Standard constructor: builds a property panel for the specified axis.
+     *
+     * @param axis  the axis, which should be changed.
+     */
+    DefaultLogAxisConfiguration(LogAxis axis, String name) {
+        super(axis, name);
+        this.manualTickUnit = axis.getTickUnit().getSize();
+    }
+
+    DefaultLogAxisConfiguration(Properties properties, String name) {
+        super(properties, name); // calling the constructor of the superclass with the Properties and name parameters
+        this.manualTickUnit = Double.valueOf(properties.getProperty(name + "." + MANUAL_TICK_UNIT));
+    }
+
+    @Override
+    void fillProperties(Properties properties) {
+        super.fillProperties(properties); // calling the fillProperties method of the superclass
+        properties.setProperty(name + "." + MANUAL_TICK_UNIT, Double.toString(manualTickUnit));
+    }
+
+    @Override
+    void setAxisProperties(Axis axis) {
+        super.setAxisProperties(axis);
+        LogAxis logAxis = (LogAxis) axis;
+        if (! isAutoTickUnitSelection) {
+            logAxis.setTickUnit(new NumberTickUnit(manualTickUnit));
+        }
+    }
+}

--- a/src/main/java/org/jfree/chart/swing/configuration/DefaultNumberAxisConfiguration.java
+++ b/src/main/java/org/jfree/chart/swing/configuration/DefaultNumberAxisConfiguration.java
@@ -1,0 +1,92 @@
+/* ===========================================================
+ * JFreeChart : a free chart library for the Java(tm) platform
+ * ===========================================================
+ *
+ * (C) Copyright 2000-2022, by David Gilbert and Contributors.
+ *
+ * Project Info:  http://www.jfree.org/jfreechart/index.html
+ *
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ * [Oracle and Java are registered trademarks of Oracle and/or its affiliates.
+ * Other names may be trademarks of their respective owners.]
+ *
+ * ----------------------------
+ * DefaultNumberAxisConfiguration.java
+ * ----------------------------
+ * (C) Copyright 2005-2022, David Gilbert and Contributors.
+ *
+ * Original Author:  David Gilbert;
+ * Contributor(s):   Arnaud Lelievre;
+ *                   Dimitry Polivaev
+ *
+ */
+
+package org.jfree.chart.swing.configuration;
+
+import java.util.Properties;
+
+import org.jfree.chart.axis.Axis;
+import org.jfree.chart.axis.NumberAxis;
+import org.jfree.chart.axis.NumberTickUnit;
+
+/**
+ * A panel for editing the properties of a value axis.
+ */
+class DefaultNumberAxisConfiguration extends DefaultValueAxisConfiguration {
+    private static final String MANUAL_TICK_UNIT = "numberAxisManualTickUnit";
+
+
+    public static boolean isContainedIn(Properties properties, String name) {
+        return properties.getProperty(name + "." + MANUAL_TICK_UNIT) != null;
+    }
+
+    private double manualTickUnit;
+
+
+    /**
+     * Standard constructor: builds a property panel for the specified axis.
+     *
+     * @param axis  the axis, which should be changed.
+     */
+    DefaultNumberAxisConfiguration(NumberAxis axis, String name) {
+
+        super(axis, name);
+
+        this.manualTickUnit = axis.getTickUnit().getSize();
+    }
+
+
+    DefaultNumberAxisConfiguration(Properties properties, String name) {
+        super(properties, name);
+        this.manualTickUnit = Double.valueOf(properties.getProperty(name + "." + MANUAL_TICK_UNIT));
+    }
+
+    @Override
+    void fillProperties(Properties properties) {
+        super.fillProperties(properties);
+        properties.setProperty(name + "." + MANUAL_TICK_UNIT, Double.toString(manualTickUnit));
+    }
+
+     @Override
+    void setAxisProperties(Axis axis) {
+        super.setAxisProperties(axis);
+        NumberAxis numberAxis = (NumberAxis) axis;
+        if (! isAutoTickUnitSelection) {
+            numberAxis.setTickUnit(new NumberTickUnit(manualTickUnit));
+        }
+    }
+}

--- a/src/main/java/org/jfree/chart/swing/configuration/DefaultPlotConfiguration.java
+++ b/src/main/java/org/jfree/chart/swing/configuration/DefaultPlotConfiguration.java
@@ -1,0 +1,259 @@
+/* ===========================================================
+ * JFreeChart : a free chart library for the Java(tm) platform
+ * ===========================================================
+ *
+ * (C) Copyright 2000-2022, by David Gilbert and Contributors.
+ *
+ * Project Info:  http://www.jfree.org/jfreechart/index.html
+ *
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ * [Oracle and Java are registered trademarks of Oracle and/or its affiliates.
+ * Other names may be trademarks of their respective owners.]
+ *
+ * ----------------------
+ * DefaultPlotConfiguration.java
+ * ----------------------
+ * (C) Copyright 2005-2022, by David Gilbert and Contributors.
+ *
+ * Original Author:  David Gilbert;
+ * Contributor(s):   Andrzej Porebski;
+ *                   Arnaud Lelievre;
+ *                   Daniel Gredler;
+ *                   Dimitry Polivaev
+ *
+ */
+
+package org.jfree.chart.swing.configuration;
+
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.util.Properties;
+
+import org.jfree.chart.axis.Axis;
+import org.jfree.chart.plot.CategoryPlot;
+import org.jfree.chart.plot.Plot;
+import org.jfree.chart.plot.PlotOrientation;
+import org.jfree.chart.plot.PolarPlot;
+import org.jfree.chart.plot.XYPlot;
+import org.jfree.chart.renderer.category.CategoryItemRenderer;
+import org.jfree.chart.renderer.category.LineAndShapeRenderer;
+import org.jfree.chart.renderer.xy.StandardXYItemRenderer;
+import org.jfree.chart.renderer.xy.XYItemRenderer;
+
+/**
+ * A panel for editing the properties of a {@link Plot}.
+ */
+class DefaultPlotConfiguration {
+    protected final String name;
+
+    private final Color backgroundColor;
+
+    private final float outlineStrokeWidth;
+
+    private final Color outlineColor;
+
+    private final RectangleInsetsConfiguration plotInsets;
+
+    private final PlotOrientation plotOrientation;
+
+    private final boolean drawLines;
+
+    private final boolean drawShapes;
+
+    private final DefaultAxisConfiguration domainAxisPropertyConfiguration;
+
+    private final DefaultAxisConfiguration rangeAxisPropertyConfiguration;
+
+    DefaultPlotConfiguration(Plot plot, String name) {
+        this.name = name;
+        this.plotInsets = new RectangleInsetsConfiguration(plot.getInsets(), name + ".plotInsets");
+        this.backgroundColor = (Color) plot.getBackgroundPaint();
+        this.outlineStrokeWidth = ((BasicStroke)plot.getOutlineStroke()).getLineWidth();
+        this.outlineColor = (Color) plot.getOutlinePaint();
+
+        if (plot instanceof CategoryPlot) {
+            this.plotOrientation = ((CategoryPlot) plot).getOrientation();
+        }
+        else if (plot instanceof XYPlot) {
+            this.plotOrientation = ((XYPlot) plot).getOrientation();
+        }
+        else
+            this.plotOrientation = null;
+
+        boolean drawLines = false;
+
+        boolean drawShapes = false;
+
+        if (plot instanceof CategoryPlot) {
+            CategoryItemRenderer renderer = ((CategoryPlot) plot).getRenderer();
+            if (renderer instanceof LineAndShapeRenderer) {
+                LineAndShapeRenderer r = (LineAndShapeRenderer) renderer;
+                drawLines = r.getDefaultLinesVisible();
+                drawShapes = r.getDefaultShapesVisible();
+            }
+        }
+        else if (plot instanceof XYPlot) {
+            XYItemRenderer renderer = ((XYPlot) plot).getRenderer();
+            if (renderer instanceof StandardXYItemRenderer) {
+                StandardXYItemRenderer r = (StandardXYItemRenderer) renderer;
+                drawLines = r.getPlotLines();
+                drawShapes = r.getBaseShapesVisible();
+            }
+        }
+        this.drawLines = drawLines;
+        this.drawShapes = drawShapes;
+
+        Axis domainAxis = null;
+        if (plot instanceof CategoryPlot) {
+            domainAxis = ((CategoryPlot) plot).getDomainAxis();
+        }
+        else if (plot instanceof XYPlot) {
+            domainAxis = ((XYPlot) plot).getDomainAxis();
+        }
+        this.domainAxisPropertyConfiguration = DefaultAxisConfiguration.getInstance(
+                domainAxis, name + "." + "domainAxis");
+
+        Axis rangeAxis = null;
+        if (plot instanceof CategoryPlot) {
+            rangeAxis = ((CategoryPlot) plot).getRangeAxis();
+        }
+        else if (plot instanceof XYPlot) {
+            rangeAxis = ((XYPlot) plot).getRangeAxis();
+        }
+        else if (plot instanceof PolarPlot) {
+            rangeAxis = ((PolarPlot) plot).getAxis();
+        }
+
+        this.rangeAxisPropertyConfiguration = DefaultAxisConfiguration.getInstance(rangeAxis,
+                name + "." + "rangeAxis");
+    }
+
+    DefaultPlotConfiguration(Properties properties, String name) {
+        this.backgroundColor = StringMapper.stringToColor(properties.getProperty(name + ".backgroundColor"));
+        this.outlineStrokeWidth = Float.parseFloat(properties.getProperty(name + ".outlineStrokeWidth"));
+        this.outlineColor = StringMapper.stringToColor(properties.getProperty(name + ".outlineColor"));
+        this.plotInsets = new RectangleInsetsConfiguration(properties, name + ".plotInsets");
+        this.plotOrientation = StringMapper.optionalStringToEnum(properties.getProperty(name + ".plotOrientation"), PlotOrientation.class);
+        this.drawLines = Boolean.parseBoolean(properties.getProperty(name + ".drawLines"));
+        this.drawShapes = Boolean.parseBoolean(properties.getProperty(name + ".drawShapes"));
+        this.domainAxisPropertyConfiguration = DefaultAxisConfiguration.getInstance(properties, name + ".domainAxis");
+        this.rangeAxisPropertyConfiguration = DefaultAxisConfiguration.getInstance(properties, name + ".rangeAxis");
+        this.name = name;
+    }
+
+    void fillProperties(Properties properties) {
+        properties.setProperty(name + ".backgroundColor", StringMapper.colorToString(backgroundColor));
+        properties.setProperty(name + ".outlineStrokeWidth", Float.toString(outlineStrokeWidth));
+        properties.setProperty(name + ".outlineColor", StringMapper.colorToString(outlineColor));
+        plotInsets.fillProperties(properties);
+        if(plotOrientation != null)
+            properties.setProperty(name + ".plotOrientation", plotOrientation.name());
+        properties.setProperty(name + ".drawLines", Boolean.toString(drawLines));
+        properties.setProperty(name + ".drawShapes", Boolean.toString(drawShapes));
+        if(domainAxisPropertyConfiguration != null)
+            domainAxisPropertyConfiguration.fillProperties(properties);
+        if(rangeAxisPropertyConfiguration != null)
+            rangeAxisPropertyConfiguration.fillProperties(properties);
+    }
+
+   void updatePlotProperties(Plot plot) {
+
+        // set the plot properties...
+        plot.setOutlinePaint(outlineColor);
+        plot.setOutlineStroke(new BasicStroke(outlineStrokeWidth, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND));
+        plot.setBackgroundPaint(backgroundColor);
+        plot.setInsets(plotInsets.getRectangleInsets());
+
+        // then the axis properties...
+        if (this.domainAxisPropertyConfiguration != null) {
+            Axis domainAxis = null;
+            if (plot instanceof CategoryPlot) {
+                CategoryPlot p = (CategoryPlot) plot;
+                domainAxis = p.getDomainAxis();
+            }
+            else if (plot instanceof XYPlot) {
+                XYPlot p = (XYPlot) plot;
+                domainAxis = p.getDomainAxis();
+            }
+            if (domainAxis != null) {
+                this.domainAxisPropertyConfiguration.setAxisProperties(domainAxis);
+            }
+        }
+
+        if (this.rangeAxisPropertyConfiguration != null) {
+            Axis rangeAxis = null;
+            if (plot instanceof CategoryPlot) {
+                CategoryPlot p = (CategoryPlot) plot;
+                rangeAxis = p.getRangeAxis();
+            }
+            else if (plot instanceof XYPlot) {
+                XYPlot p = (XYPlot) plot;
+                rangeAxis = p.getRangeAxis();
+            }
+            else if (plot instanceof PolarPlot) {
+                PolarPlot p = (PolarPlot) plot;
+                rangeAxis = p.getAxis();
+            }
+            if (rangeAxis != null) {
+                this.rangeAxisPropertyConfiguration.setAxisProperties(rangeAxis);
+            }
+        }
+
+        if (this.plotOrientation != null) {
+            if (plot instanceof CategoryPlot) {
+                CategoryPlot p = (CategoryPlot) plot;
+                p.setOrientation(this.plotOrientation);
+            }
+            else if (plot instanceof XYPlot) {
+                XYPlot p = (XYPlot) plot;
+                p.setOrientation(this.plotOrientation);
+            }
+        }
+
+        if (plot instanceof CategoryPlot) {
+            CategoryPlot p = (CategoryPlot) plot;
+            CategoryItemRenderer r = p.getRenderer();
+            if (r instanceof LineAndShapeRenderer) {
+                ((LineAndShapeRenderer) r).setDefaultLinesVisible(this.drawLines);
+            }
+        }
+        else if (plot instanceof XYPlot) {
+            XYPlot p = (XYPlot) plot;
+            XYItemRenderer r = p.getRenderer();
+            if (r instanceof StandardXYItemRenderer) {
+                ((StandardXYItemRenderer) r).setPlotLines(this.drawLines);
+            }
+        }
+
+        if (plot instanceof CategoryPlot) {
+            CategoryPlot p = (CategoryPlot) plot;
+            CategoryItemRenderer r = p.getRenderer();
+            if (r instanceof LineAndShapeRenderer) {
+                ((LineAndShapeRenderer) r).setDefaultShapesVisible(this.drawShapes);
+            }
+        }
+        else if (plot instanceof XYPlot) {
+            XYPlot p = (XYPlot) plot;
+            XYItemRenderer r = p.getRenderer();
+            if (r instanceof StandardXYItemRenderer) {
+                ((StandardXYItemRenderer) r).setBaseShapesVisible(
+                        this.drawShapes);
+            }
+        }
+
+    }
+}

--- a/src/main/java/org/jfree/chart/swing/configuration/DefaultPolarPlotConfiguration.java
+++ b/src/main/java/org/jfree/chart/swing/configuration/DefaultPolarPlotConfiguration.java
@@ -1,0 +1,78 @@
+/* ===========================================================
+ * JFreeChart : a free chart library for the Java(tm) platform
+ * ===========================================================
+ *
+ * (C) Copyright 2000-2022, by David Gilbert and Contributors.
+ *
+ * Project Info:  http://www.jfree.org/jfreechart/index.html
+ *
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ * [Oracle and Java are registered trademarks of Oracle and/or its affiliates.
+ * Other names may be trademarks of their respective owners.]
+ *
+ * ----------------------
+ * DefaultPolarPlotConfiguration.java
+ * ----------------------
+ * (C) Copyright 2005-2022, by David Gilbert and Contributors.
+ *
+ * Original Author:  Martin Hoeller;
+ * Contributor(s):   Dimitry Polivaev;
+ *
+ */
+
+
+package org.jfree.chart.swing.configuration;
+
+import java.util.Properties;
+
+import org.jfree.chart.axis.NumberTickUnit;
+import org.jfree.chart.plot.Plot;
+import org.jfree.chart.plot.PolarPlot;
+
+class DefaultPolarPlotConfiguration extends DefaultPlotConfiguration {
+    private double manualTickUnit;
+
+    private double angleOffset;
+
+   DefaultPolarPlotConfiguration(PolarPlot plot, String name) {
+        super(plot, name);
+        this.angleOffset = plot.getAngleOffset();
+        this.manualTickUnit = plot.getAngleTickUnit().getSize();
+    }
+
+
+   DefaultPolarPlotConfiguration(Properties properties, String name) {
+       super(properties, name);
+       this.manualTickUnit = Double.valueOf(properties.getProperty(name + "." + "manualTickUnit"));
+       this.angleOffset = Double.valueOf(properties.getProperty(name + "." + "angleOffset"));
+   }
+
+   @Override
+   void fillProperties(Properties properties) {
+       super.fillProperties(properties);
+       properties.setProperty(name + "." + "manualTickUnit", Double.toString(manualTickUnit));
+       properties.setProperty(name + "." + "angleOffset", Double.toString(angleOffset));
+   }
+
+   @Override
+    void updatePlotProperties(Plot plot) {
+        super.updatePlotProperties(plot);
+        PolarPlot pp = (PolarPlot) plot;
+        pp.setAngleTickUnit(new NumberTickUnit(this.manualTickUnit));
+        pp.setAngleOffset(this.angleOffset);
+    }
+}

--- a/src/main/java/org/jfree/chart/swing/configuration/DefaultTitleConfiguration.java
+++ b/src/main/java/org/jfree/chart/swing/configuration/DefaultTitleConfiguration.java
@@ -1,0 +1,111 @@
+/* ===========================================================
+ * JFreeChart : a free chart library for the Java(tm) platform
+ * ===========================================================
+ *
+ * (C) Copyright 2000-2022, by David Gilbert and Contributors.
+ *
+ * Project Info:  http://www.jfree.org/jfreechart/index.html
+ *
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ * [Oracle and Java are registered trademarks of Oracle and/or its affiliates.
+ * Other names may be trademarks of their respective owners.]
+ *
+ * -----------------------
+ * DefaultTitleConfiguration.java
+ * -----------------------
+ * (C) Copyright 2005-2022, by David Gilbert.
+ *
+ * Original Author:  David Gilbert;
+ * Contributor(s):   Arnaud Lelievre;
+ *                   Daniel Gredler;
+ *                   Dimitry Polivaev;
+ *
+ */
+
+package org.jfree.chart.swing.configuration;
+
+import java.awt.Color;
+import java.awt.Font;
+import java.util.Properties;
+
+import org.jfree.chart.JFreeChart;
+import org.jfree.chart.title.TextTitle;
+import org.jfree.chart.title.Title;
+
+class DefaultTitleConfiguration {
+    private final String name;
+
+    private final boolean showTitle;
+
+    private final String titleText;
+
+    private final Font titleFont;
+
+    private final Color titleColor;
+
+
+    /**
+     * Standard constructor: builds a panel for displaying/editing the
+     * properties of the specified title.
+     *
+     * @param title  the title, which should be changed.
+     */
+    DefaultTitleConfiguration(Title title, String name) {
+
+        this.name = name;
+        TextTitle t = (title != null ? (TextTitle) title
+                : new TextTitle());
+        this.showTitle = (title != null);
+        this.titleFont = t.getFont();
+        this.titleText = t.getText();
+        this.titleColor = (Color) t.getPaint();
+    }
+
+    DefaultTitleConfiguration(Properties properties, java.lang.String name) {
+        this.name = name;
+        this.showTitle = Boolean.valueOf(properties.getProperty(name + "." + "showTitle"));
+        this.titleFont = StringMapper.stringToFont(properties.getProperty(name + "." + "titleFont"));
+        this.titleText = properties.getProperty(name + "." + "titleText");
+        this.titleColor = StringMapper.stringToColor(properties.getProperty(name + "." + "titleColor"));
+
+    }
+
+
+    void fillProperties(Properties properties) {
+        properties.setProperty(name + "." + "showTitle", Boolean.toString(showTitle));
+        properties.setProperty(name + "." + "titleFont", StringMapper.fontToString(titleFont));
+        properties.setProperty(name + "." + "titleText", titleText);
+        properties.setProperty(name + "." + "titleColor", StringMapper.colorToString(titleColor));
+    }
+
+    void setTitleProperties(JFreeChart chart) {
+        if (this.showTitle) {
+            TextTitle title = chart.getTitle();
+            if (title == null) {
+                title = new TextTitle();
+                chart.setTitle(title);
+            }
+            title.setText(titleText);
+            title.setFont(titleFont);
+            title.setPaint(titleColor);
+        }
+        else {
+            chart.setTitle((TextTitle) null);
+        }
+    }
+
+}

--- a/src/main/java/org/jfree/chart/swing/configuration/DefaultValueAxisConfiguration.java
+++ b/src/main/java/org/jfree/chart/swing/configuration/DefaultValueAxisConfiguration.java
@@ -1,0 +1,138 @@
+/* ===========================================================
+ * JFreeChart : a free chart library for the Java(tm) platform
+ * ===========================================================
+ *
+ * (C) Copyright 2000-2022, by David Gilbert and Contributors.
+ *
+ * Project Info:  http://www.jfree.org/jfreechart/index.html
+ *
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ * [Oracle and Java are registered trademarks of Oracle and/or its affiliates.
+ * Other names may be trademarks of their respective owners.]
+ *
+ * ---------------------------
+ * DefaultValueAxisConfiguration.java
+ * ---------------------------
+ * (C) Copyright 2005-2022, by David Gilbert and Contributors.
+ *
+ * Original Author:  Martin Hoeller (base on DefaultNumberAxisConfiguration
+ *                                   by David Gilbert);
+ * Contributor(s):   Dimitry Polivaev;
+ *
+ */
+
+package org.jfree.chart.swing.configuration;
+
+import java.awt.Color;
+import java.util.Properties;
+
+import org.jfree.chart.axis.Axis;
+import org.jfree.chart.axis.ValueAxis;
+
+/**
+ * A panel for editing properties of a {@link ValueAxis}.
+ */
+class DefaultValueAxisConfiguration extends DefaultAxisConfiguration {
+
+    public static boolean isContainedIn(Properties properties, String name) {
+        return properties.getProperty(name + "." + "autoRange") != null;
+    }
+    /** A flag that indicates whether or not the axis range is determined
+     *  automatically.
+     */
+    private final boolean autoRange;
+
+    /** Flag if auto-tickunit-selection is enabled. */
+    protected final boolean isAutoTickUnitSelection;
+
+    /** The lowest value in the axis range. */
+    private final double minimum;
+
+    /** The highest value in the axis range. */
+    private final double maximum;
+
+    /** A text field for entering the minimum value in the axis range. */
+    private final String minimumRange;
+
+    /** A text field for entering the maximum value in the axis range. */
+    private final String maximumRange;
+
+    /** The paint selected for drawing the gridlines. */
+    private final Color gridColor;
+
+    /** The stroke selected for drawing the gridlines. */
+    private final float gridStrokeWidth;
+
+    /**
+     * Standard constructor: builds a property panel for the specified axis.
+     *
+     * @param axis  the axis, which should be changed.
+     */
+    DefaultValueAxisConfiguration(ValueAxis axis, String name) {
+
+        super(axis, name);
+
+        this.autoRange = axis.isAutoRange();
+        this.minimum = axis.getLowerBound();
+        this.maximum = axis.getUpperBound();
+        this.isAutoTickUnitSelection = axis.isAutoTickUnitSelection();
+
+        this.gridColor = Color.BLUE;
+        this.gridStrokeWidth = 1f;
+
+        this.minimumRange = Double.toString(
+                this.minimum);
+         this.maximumRange = Double.toString(
+                this.maximum);
+      }
+
+    DefaultValueAxisConfiguration(Properties properties, String name) {
+        super(properties, name);
+        this.autoRange = Boolean.parseBoolean(properties.getProperty(name + ".autoRange"));
+        this.isAutoTickUnitSelection = Boolean.parseBoolean(properties.getProperty(name + ".autoTickUnitSelection"));
+        this.minimum = Double.parseDouble(properties.getProperty(name + ".minimum"));
+        this.maximum = Double.parseDouble(properties.getProperty(name + ".maximum"));
+        this.minimumRange = properties.getProperty(name + ".minimumRange");
+        this.maximumRange = properties.getProperty(name + ".maximumRange");
+        this.gridColor = StringMapper.stringToColor(properties.getProperty(name + ".gridColor"));
+        this.gridStrokeWidth = Float.parseFloat(properties.getProperty(name + ".gridStrokeWidth"));
+    }
+
+    @Override
+    void fillProperties(Properties properties) {
+        super.fillProperties(properties);
+        properties.setProperty(name + ".autoRange", Boolean.toString(autoRange));
+        properties.setProperty(name + ".autoTickUnitSelection", Boolean.toString(isAutoTickUnitSelection));
+        properties.setProperty(name + ".minimum", Double.toString(minimum));
+        properties.setProperty(name + ".maximum", Double.toString(maximum));
+        properties.setProperty(name + ".minimumRange", minimumRange);
+        properties.setProperty(name + ".maximumRange", maximumRange);
+        properties.setProperty(name + ".gridColor", StringMapper.colorToString(gridColor));
+        properties.setProperty(name + ".gridStrokeWidth", Float.toString(gridStrokeWidth));
+    }
+
+    @Override
+    void setAxisProperties(Axis axis) {
+        super.setAxisProperties(axis);
+        ValueAxis valueAxis = (ValueAxis) axis;
+        valueAxis.setAutoRange(this.autoRange);
+        if (!this.autoRange) {
+            valueAxis.setRange(this.minimum, this.maximum);
+        }
+        valueAxis.setAutoTickUnitSelection(this.isAutoTickUnitSelection);
+    }
+}

--- a/src/main/java/org/jfree/chart/swing/configuration/RectangleInsetsConfiguration.java
+++ b/src/main/java/org/jfree/chart/swing/configuration/RectangleInsetsConfiguration.java
@@ -1,0 +1,74 @@
+/* ===========================================================
+ * JFreeChart : a free chart library for the Java(tm) platform
+ * ===========================================================
+ *
+ * (C) Copyright 2000-2022, by David Gilbert and Contributors.
+ *
+ * Project Info:  http://www.jfree.org/jfreechart/index.html
+ *
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ * [Oracle and Java are registered trademarks of Oracle and/or its affiliates.
+ * Other names may be trademarks of their respective owners.]
+ *
+ * ---------------------------
+ * RectangleInsetsConfiguration.java
+ * ---------------------------
+ * (C) Copyright 2005-2022, by David Gilbert and Contributors.
+ *
+ * Original Author:  Dimitry Polivaev;
+ *
+ * Contributor(s):   -;
+ *
+ */
+package org.jfree.chart.swing.configuration;
+
+import java.util.Properties;
+
+import org.jfree.chart.api.RectangleInsets;
+import org.jfree.chart.api.UnitType;
+
+class RectangleInsetsConfiguration {
+
+    private final RectangleInsets rectangleInsets;
+    private final String name;
+
+    RectangleInsetsConfiguration(RectangleInsets rectangleInsets, String name) {
+        this.rectangleInsets = rectangleInsets;
+        this.name = name;
+    }
+
+    RectangleInsetsConfiguration(Properties properties, String name) {
+        this.name = name;
+        UnitType unitType = UnitType.valueOf(properties.getProperty(name + "." + "unitType"));
+        double top = Double.valueOf(properties.getProperty(name + "." + "top"));
+        double left = Double.valueOf(properties.getProperty(name + "." + "left"));
+        double bottom = Double.valueOf(properties.getProperty(name + "." + "bottom"));
+        double right = Double.valueOf(properties.getProperty(name + "." + "right"));
+        this.rectangleInsets = new RectangleInsets(unitType, top, left, bottom, right);
+    }
+
+    void fillProperties(Properties properties) {
+        properties.setProperty(name + "." + "unitType", rectangleInsets.getUnitType().toString());
+        properties.setProperty(name + "." + "top", Double.toString(rectangleInsets.getTop()));
+        properties.setProperty(name + "." + "left", Double.toString(rectangleInsets.getLeft()));
+        properties.setProperty(name + "." + "bottom", Double.toString(rectangleInsets.getBottom()));
+        properties.setProperty(name + "." + "right", Double.toString(rectangleInsets.getRight()));
+    }
+    RectangleInsets getRectangleInsets() {
+         return rectangleInsets;
+    }
+}

--- a/src/main/java/org/jfree/chart/swing/configuration/StringMapper.java
+++ b/src/main/java/org/jfree/chart/swing/configuration/StringMapper.java
@@ -1,0 +1,94 @@
+/* ===========================================================
+ * JFreeChart : a free chart library for the Java(tm) platform
+ * ===========================================================
+ *
+ * (C) Copyright 2000-2022, by David Gilbert and Contributors.
+ *
+ * Project Info:  http://www.jfree.org/jfreechart/index.html
+ *
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ * [Oracle and Java are registered trademarks of Oracle and/or its affiliates.
+ * Other names may be trademarks of their respective owners.]
+ *
+ * ---------------------------
+ * StringMapper.java
+ * ---------------------------
+ * (C) Copyright 2005-2022, by David Gilbert and Contributors.
+ *
+ * Original Author:  Dimitry Polivaev;
+ *
+ * Contributor(s):   -;
+ *
+ */
+package org.jfree.chart.swing.configuration;
+
+import java.awt.Color;
+import java.awt.Font;
+
+class StringMapper{
+
+    static Color stringToColor(String color) {
+            if (color == null) {
+                return null;
+            }
+            if (color.length() != 7 || color.charAt(0) != '#') {
+                throw new NumberFormatException("wrong color format in " + color + ". Expecting #rrggbb");
+            }
+            final int r = Integer.parseInt(color.substring(1, 3), 16);
+            final int g = Integer.parseInt(color.substring(3, 5), 16);
+            final int b = Integer.parseInt(color.substring(5, 7), 16);
+            return new Color(r, g, b);
+        }
+
+    public static String colorToString(final Color col) {
+        if (col == null) {
+            return null;
+        }
+        return String.format("#%02x%02x%02x", col.getRed(), col.getGreen(), col.getBlue());
+    }
+
+
+    static Font stringToFont(String font) {
+        return Font.decode(font);
+    }
+
+    static String fontToString(Font font) {
+        // Font name
+        String str = font.getName();
+
+        // Font style
+        int style = font.getStyle();
+        if (style == Font.PLAIN) {
+            str += "-PLAIN";
+        } if (style == Font.BOLD) {
+            str += "-BOLD";
+        } else if (style == Font.ITALIC) {
+            str += "-ITALIC";
+        } else if (style == (Font.BOLD | Font.ITALIC)) {
+            str += "-BOLDITALIC";
+        }
+
+        // Font size
+        str += "-" + font.getSize();
+
+        return str;
+    }
+
+    static <T extends Enum<T>> T optionalStringToEnum(String optionalString, Class<T> enumClass) {
+        return optionalString == null ? null : Enum.valueOf(enumClass, optionalString);
+    }
+}

--- a/src/main/java/org/jfree/chart/swing/configuration/package-info.java
+++ b/src/main/java/org/jfree/chart/swing/configuration/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Provides a simple (but so far incomplete) framework for saving editable chart properties.
+ */
+package org.jfree.chart.swing.configuration;

--- a/src/test/java/org/jfree/chart/swing/configuration/DefaultChartConfigurationTest.java
+++ b/src/test/java/org/jfree/chart/swing/configuration/DefaultChartConfigurationTest.java
@@ -1,0 +1,106 @@
+/* ===========================================================
+ * JFreeChart : a free chart library for the Java(tm) platform
+ * ===========================================================
+ *
+ * (C) Copyright 2000-2022, by David Gilbert and Contributors.
+ *
+ * Project Info:  http://www.jfree.org/jfreechart/index.html
+ *
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ * [Oracle and Java are registered trademarks of Oracle and/or its affiliates.
+ * Other names may be trademarks of their respective owners.]
+ *
+ * ---------------------------
+ * DefaultChartConfigurationTest.java
+ * ---------------------------
+ * (C) Copyright 2005-2022, by David Gilbert and Contributors.
+ *
+ * Original Author:  Dimitry Polivaev;
+ *
+ * Contributor(s):   -;
+ *
+ */
+
+package org.jfree.chart.swing.configuration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.awt.Color;
+import java.awt.Font;
+import java.util.Properties;
+
+import org.jfree.chart.ChartFactory;
+import org.jfree.chart.JFreeChart;
+import org.jfree.chart.axis.LogAxis;
+import org.jfree.chart.plot.XYPlot;
+import org.jfree.data.general.DefaultPieDataset;
+import org.jfree.data.xy.DefaultXYDataset;
+import org.junit.jupiter.api.Test;
+
+public class DefaultChartConfigurationTest {
+    private static void verifyRoundTrip(JFreeChart chart, JFreeChart updatedChart) {
+        DefaultChartConfiguration saved = new DefaultChartConfiguration(chart);
+        Properties savedProperties = saved.getProperties();
+        DefaultChartConfiguration uut = new DefaultChartConfiguration(savedProperties);
+        Properties roundtripProperties = uut.getProperties();
+        assertEquals(savedProperties, roundtripProperties);
+        uut.updateChart(updatedChart);
+        assertEquals(chart, updatedChart);
+
+    }
+
+    @Test
+    void pieChartRoundTrip() {
+        JFreeChart chart = ChartFactory.createPieChart("title", new DefaultPieDataset<>());
+        JFreeChart updatedChart = ChartFactory.createPieChart("title", new DefaultPieDataset<>());
+        verifyRoundTrip(chart, updatedChart);
+    }
+
+    @Test
+    void polarChartRoundTrip() {
+        JFreeChart chart = ChartFactory.createPolarChart("title", new DefaultXYDataset<>(), true, true, true);
+        JFreeChart updatedChart = ChartFactory.createPolarChart("title", new DefaultXYDataset<>(), true, true, true);
+        verifyRoundTrip(chart, updatedChart);
+    }
+
+    @Test
+    void xyLineChartRoundTrip() {
+        JFreeChart chart = ChartFactory.createXYLineChart("title", "x", "y", new DefaultXYDataset<>());
+        chart.setBackgroundPaint(Color.RED);
+        chart.setAntiAlias(true);
+        JFreeChart updatedChart = ChartFactory.createXYLineChart("title", "x", "y", new DefaultXYDataset<>());
+        updatedChart.setBackgroundPaint(Color.BLUE);
+        chart.setAntiAlias(false);
+        verifyRoundTrip(chart, updatedChart);
+    }
+
+
+    @Test
+    void logAxisXyLineChartRoundTrip() {
+        JFreeChart chart = ChartFactory.createXYLineChart("title", "x", "y", new DefaultXYDataset<>());
+        LogAxis axis = new LogAxis("logX");
+        axis.setLabelFont(new Font("dialog", Font.BOLD | Font.ITALIC, 24));
+        ((XYPlot<?>) chart.getPlot()).setDomainAxis(axis);
+        chart.setBackgroundPaint(Color.RED);
+        chart.setAntiAlias(true);
+        JFreeChart updatedChart = ChartFactory.createXYLineChart("title", "x", "y", new DefaultXYDataset<>());
+        updatedChart.setBackgroundPaint(Color.BLUE);
+        ((XYPlot<?>) updatedChart.getPlot()).setDomainAxis(new LogAxis("logY"));
+        chart.setAntiAlias(false);
+        verifyRoundTrip(chart, updatedChart);
+    }
+}


### PR DESCRIPTION
Added package saves all chart configuration properties which can be edited by swing editors so that they can be serialized in any format as a key-value property map.

I am going to use it with https://github.com/freeplane/freeplane so that configured charts can be saved in freeplane mind maps.