### PR TITLE
CVE-2024-23077.

### DIFF
--- a/src/main/java/org/jfree/chart/plot/CompassPlot.java
+++ b/src/main/java/org/jfree/chart/plot/CompassPlot.java
@@ -464,7 +464,7 @@ public class CompassPlot extends Plot implements Cloneable, Serializable {
      * @param needle  the needle.
      */
     public void setSeriesNeedle(int index, MeterNeedle needle) {
-        if ((needle != null) && (index < this.seriesNeedle.length)) {
+        if ((needle != null) && (index >= 0) && (index < this.seriesNeedle.length)) {
             this.seriesNeedle[index] = needle;
         }
         fireChangeEvent();

--- a/src/test/java/org/jfree/chart/plot/CompassPlotTest.java
+++ b/src/test/java/org/jfree/chart/plot/CompassPlotTest.java
@@ -41,7 +41,7 @@ import java.awt.Font;
 import java.awt.GradientPaint;
 
 import org.jfree.chart.TestUtils;
-
+import org.jfree.chart.needle.PointerNeedle;
 import org.jfree.data.general.DefaultValueDataset;
 import org.junit.jupiter.api.Test;
 
@@ -130,6 +130,15 @@ public class CompassPlotTest {
         assertNotSame(p1, p2);
         assertSame(p1.getClass(), p2.getClass());
         assertEquals(p1, p2);
+    }
+
+    /**
+     * Test faulty array bounds; CVE-2024-23077.
+     */
+    @Test
+    public void testArrayBounds() {
+        CompassPlot p = new CompassPlot(new DefaultValueDataset(0));
+        p.setSeriesNeedle(-1, new PointerNeedle());
     }
 
 }


### PR DESCRIPTION
In v1.5.x, add check and test for lower array bound to `CompassPlot::setSeriesNeedle`, mentioned in [CVE-2024-23077](https://github.com/advisories/GHSA-jfc7-fvxq-663f) and [CVE-2023-52070](https://github.com/advisories/GHSA-872f-jfmv-qjp2), raised in issue #396. 