### PR TITLE
Add crosshair label padding and adjusted crosshair label position when LabelAnchor is center

### DIFF
--- a/src/main/java/org/jfree/chart/plot/Crosshair.java
+++ b/src/main/java/org/jfree/chart/plot/Crosshair.java
@@ -47,6 +47,7 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
+import org.jfree.chart.api.RectangleInsets;
 import org.jfree.chart.internal.HashUtils;
 import org.jfree.chart.labels.CrosshairLabelGenerator;
 import org.jfree.chart.labels.StandardCrosshairLabelGenerator;
@@ -107,6 +108,11 @@ public class Crosshair implements Cloneable, PublicCloneable, Serializable {
      * The y-offset in Java2D units.
      */
     private double labelYOffset;
+
+    /**
+     * The label padding.
+     */
+    private RectangleInsets labelPadding;
 
     /**
      * The label font.
@@ -170,6 +176,7 @@ public class Crosshair implements Cloneable, PublicCloneable, Serializable {
         this.labelAnchor = RectangleAnchor.BOTTOM_LEFT;
         this.labelXOffset = 5.0;
         this.labelYOffset = 5.0;
+        this.labelPadding = RectangleInsets.ZERO_INSETS;
         this.labelFont = new Font("Tahoma", Font.PLAIN, 12);
         this.labelPaint = Color.BLACK;
         this.labelBackgroundPaint = new Color(0, 0, 255, 63);
@@ -410,6 +417,30 @@ public class Crosshair implements Cloneable, PublicCloneable, Serializable {
     }
 
     /**
+     * Returns the label padding.
+     *
+     * @return The label padding (never {@code null}).
+     * @see #setLabelPadding
+     */
+    public RectangleInsets getLabelPadding() {
+        return labelPadding;
+    }
+
+    /**
+     * Sets the label padding and sends a property change event (with the name
+     * 'labelPadding') to all registered listeners.
+     *
+     * @param padding the padding ({@code null} not permitted).
+     * @see #getLabelPadding()
+     */
+    public void setLabelPadding(RectangleInsets padding) {
+        Args.nullNotPermitted(padding, "padding");
+        RectangleInsets old = this.labelPadding;
+        this.labelPadding = padding;
+        this.pcs.firePropertyChange("labelPadding", old, padding);
+    }
+
+    /**
      * Returns the label font.
      *
      * @return The label font (never {@code null}).
@@ -609,6 +640,9 @@ public class Crosshair implements Cloneable, PublicCloneable, Serializable {
         if (this.labelYOffset != that.labelYOffset) {
             return false;
         }
+        if (!this.labelPadding.equals(labelPadding)) {
+            return false;
+        }
         if (!this.labelFont.equals(that.labelFont)) {
             return false;
         }
@@ -649,6 +683,7 @@ public class Crosshair implements Cloneable, PublicCloneable, Serializable {
         hash = HashUtils.hashCode(hash, this.labelGenerator);
         hash = HashUtils.hashCode(hash, this.labelXOffset);
         hash = HashUtils.hashCode(hash, this.labelYOffset);
+        hash = HashUtils.hashCode(hash, this.labelPadding);
         hash = HashUtils.hashCode(hash, this.labelFont);
         hash = HashUtils.hashCode(hash, this.labelPaint);
         hash = HashUtils.hashCode(hash, this.labelBackgroundPaint);

--- a/src/main/java/org/jfree/chart/swing/CrosshairOverlay.java
+++ b/src/main/java/org/jfree/chart/swing/CrosshairOverlay.java
@@ -293,6 +293,16 @@ public class CrosshairOverlay extends AbstractOverlay implements Overlay,
                         pt = calculateLabelPoint(line, anchor, crosshair.getLabelXOffset(), crosshair.getLabelYOffset(), padding);
                         xx = (float) pt.getX();
                         yy = (float) pt.getY();
+                        if (anchor == RectangleAnchor.CENTER || alignPt.isHalfAscent()) {
+                            double labelHeight = hotspot.getBounds2D().getHeight();
+                            double minY = dataArea.getY() + (labelHeight + padding.getTop() - padding.getBottom()) / 2.0;
+                            double maxY = dataArea.getY() + dataArea.getHeight() - (labelHeight + padding.getBottom() - padding.getTop()) / 2.0;
+                            if (yy < minY) {
+                                yy = (float) (minY);
+                            } else if (yy > maxY) {
+                                yy = (float) (maxY);
+                            }
+                        }
                         alignPt = textAlignPtForLabelAnchorH(anchor);
                         hotspot = TextUtils.calculateRotatedStringBounds(
                                label, g2, xx, yy, alignPt, 0.0, TextAnchor.CENTER);
@@ -355,6 +365,16 @@ public class CrosshairOverlay extends AbstractOverlay implements Overlay,
                         pt = calculateLabelPoint(line, anchor, crosshair.getLabelXOffset(), crosshair.getLabelYOffset(), padding);
                         xx = (float) pt.getX();
                         yy = (float) pt.getY();
+                        if (alignPt.isHorizontalCenter()) {
+                            double labelWidth = hotspot.getBounds2D().getWidth();
+                            double minX = dataArea.getX() + (labelWidth + padding.getLeft() - padding.getRight()) / 2.0;
+                            double maxX = dataArea.getX() + dataArea.getWidth() - (labelWidth + padding.getRight() - padding.getLeft()) / 2.0;
+                            if (xx < minX) {
+                                xx = (float) (minX);
+                            } else if (xx > maxX) {
+                                xx = (float) (maxX);
+                            }
+                        }
                         alignPt = textAlignPtForLabelAnchorV(anchor);
                         hotspot = TextUtils.calculateRotatedStringBounds(
                                label, g2, xx, yy, alignPt, 0.0, TextAnchor.CENTER);

--- a/src/main/java/org/jfree/chart/swing/CrosshairOverlay.java
+++ b/src/main/java/org/jfree/chart/swing/CrosshairOverlay.java
@@ -51,6 +51,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import org.jfree.chart.JFreeChart;
+import org.jfree.chart.api.RectangleInsets;
 import org.jfree.chart.axis.ValueAxis;
 import org.jfree.chart.plot.Crosshair;
 import org.jfree.chart.plot.PlotOrientation;
@@ -279,20 +280,23 @@ public class CrosshairOverlay extends AbstractOverlay implements Overlay,
                     Font savedFont = g2.getFont();
                     g2.setFont(crosshair.getLabelFont());
                     RectangleAnchor anchor = crosshair.getLabelAnchor();
-                    Point2D pt = calculateLabelPoint(line, anchor, crosshair.getLabelXOffset(), crosshair.getLabelYOffset());
+                    RectangleInsets padding = crosshair.getLabelPadding();
+                    Point2D pt = calculateLabelPoint(line, anchor, crosshair.getLabelXOffset(), crosshair.getLabelYOffset(), padding);
                     float xx = (float) pt.getX();
                     float yy = (float) pt.getY();
                     TextAnchor alignPt = textAlignPtForLabelAnchorH(anchor);
                     Shape hotspot = TextUtils.calculateRotatedStringBounds(
                             label, g2, xx, yy, alignPt, 0.0, TextAnchor.CENTER);
+                    hotspot = padding.createOutsetRectangle(hotspot.getBounds2D());
                     if (!dataArea.contains(hotspot.getBounds2D())) {
                         anchor = flipAnchorV(anchor);
-                        pt = calculateLabelPoint(line, anchor, crosshair.getLabelXOffset(), crosshair.getLabelYOffset());
+                        pt = calculateLabelPoint(line, anchor, crosshair.getLabelXOffset(), crosshair.getLabelYOffset(), padding);
                         xx = (float) pt.getX();
                         yy = (float) pt.getY();
                         alignPt = textAlignPtForLabelAnchorH(anchor);
                         hotspot = TextUtils.calculateRotatedStringBounds(
                                label, g2, xx, yy, alignPt, 0.0, TextAnchor.CENTER);
+                        hotspot = padding.createOutsetRectangle(hotspot.getBounds2D());
                     }
 
                     g2.setPaint(crosshair.getLabelBackgroundPaint());
@@ -338,20 +342,23 @@ public class CrosshairOverlay extends AbstractOverlay implements Overlay,
                     Font savedFont = g2.getFont();
                     g2.setFont(crosshair.getLabelFont());
                     RectangleAnchor anchor = crosshair.getLabelAnchor();
-                    Point2D pt = calculateLabelPoint(line, anchor, crosshair.getLabelXOffset(), crosshair.getLabelYOffset());
+                    RectangleInsets padding = crosshair.getLabelPadding();
+                    Point2D pt = calculateLabelPoint(line, anchor, crosshair.getLabelXOffset(), crosshair.getLabelYOffset(), padding);
                     float xx = (float) pt.getX();
                     float yy = (float) pt.getY();
                     TextAnchor alignPt = textAlignPtForLabelAnchorV(anchor);
                     Shape hotspot = TextUtils.calculateRotatedStringBounds(
                             label, g2, xx, yy, alignPt, 0.0, TextAnchor.CENTER);
+                    hotspot = padding.createOutsetRectangle(hotspot.getBounds2D());
                     if (!dataArea.contains(hotspot.getBounds2D())) {
                         anchor = flipAnchorH(anchor);
-                        pt = calculateLabelPoint(line, anchor, crosshair.getLabelXOffset(), crosshair.getLabelYOffset());
+                        pt = calculateLabelPoint(line, anchor, crosshair.getLabelXOffset(), crosshair.getLabelYOffset(), padding);
                         xx = (float) pt.getX();
                         yy = (float) pt.getY();
                         alignPt = textAlignPtForLabelAnchorV(anchor);
                         hotspot = TextUtils.calculateRotatedStringBounds(
                                label, g2, xx, yy, alignPt, 0.0, TextAnchor.CENTER);
+                        hotspot = padding.createOutsetRectangle(hotspot.getBounds2D());
                     }
                     g2.setPaint(crosshair.getLabelBackgroundPaint());
                     g2.fill(hotspot);
@@ -377,11 +384,12 @@ public class CrosshairOverlay extends AbstractOverlay implements Overlay,
      * @param anchor  the anchor point.
      * @param deltaX  the x-offset.
      * @param deltaY  the y-offset.
+     * @param padding the label padding
      *
      * @return The anchor point.
      */
     private Point2D calculateLabelPoint(Line2D line, RectangleAnchor anchor,
-            double deltaX, double deltaY) {
+            double deltaX, double deltaY, RectangleInsets padding) {
         double x, y;
         boolean left = (anchor == RectangleAnchor.BOTTOM_LEFT 
                 || anchor == RectangleAnchor.LEFT 
@@ -402,32 +410,36 @@ public class CrosshairOverlay extends AbstractOverlay implements Overlay,
             x = line.getX1();
             y = (line.getY1() + line.getY2()) / 2.0;
             if (left) {
-                x = x - deltaX;
-            }
-            if (right) {
-                x = x + deltaX;
+                x = x - deltaX - padding.getRight();
+            } else if (right) {
+                x = x + deltaX + padding.getLeft();
+            } else {
+                x = x + (padding.getLeft() - padding.getRight()) / 2.0;
             }
             if (top) {
-                y = Math.min(line.getY1(), line.getY2()) + deltaY;
-            }
-            if (bottom) {
-                y = Math.max(line.getY1(), line.getY2()) - deltaY;
+                y = Math.min(line.getY1(), line.getY2()) + deltaY + padding.getTop();
+            } else if (bottom) {
+                y = Math.max(line.getY1(), line.getY2()) - deltaY - padding.getBottom();
+            } else {
+                y = y + (padding.getTop() - padding.getBottom()) / 2.0;
             }
         }
         else {  // horizontal
             x = (line.getX1() + line.getX2()) / 2.0;
             y = line.getY1();
             if (left) {
-                x = Math.min(line.getX1(), line.getX2()) + deltaX;
-            }
-            if (right) {
-                x = Math.max(line.getX1(), line.getX2()) - deltaX;
+                x = Math.min(line.getX1(), line.getX2()) + deltaX + padding.getLeft();
+            } else if (right) {
+                x = Math.max(line.getX1(), line.getX2()) - deltaX - padding.getRight();
+            } else {
+                x = x + (padding.getLeft() - padding.getRight()) / 2.0;
             }
             if (top) {
-                y = y - deltaY;
-            }
-            if (bottom) {
-                y = y + deltaY;
+                y = y - deltaY - padding.getBottom();
+            } else if (bottom) {
+                y = y + deltaY + padding.getTop();
+            } else {
+                y = y + (padding.getTop() - padding.getBottom()) / 2.0;
             }
         }
         return new Point2D.Double(x, y);


### PR DESCRIPTION
This PR I has add new crosshair label padding that draw over the `CrosshairOverlay`. and adjusted crosshair label position to be within chart dataArea when LabelAnchor is `CENTER`. this changed apply for both `domainCrosshair` and `rangeCrosshair`
#### Before and no adjusted label position
![before](https://github.com/user-attachments/assets/c52a8741-a4c0-4142-ba70-eb1607e2fb44)
#### After update and apply padding
`crosshair.setLabelPadding(new RectangleInsets(3, 5, 3, 5));`

![after](https://github.com/user-attachments/assets/8a313a72-2406-408e-b553-d5841f695d8c)

Please check this PR I hope this option have in this JFreeChart. or something wrong with this changed please help improve the code changed. Thank you.