### PR TITLE
Fix container inefficiencies in FlowArrangement.java and XYPlot.java

### DIFF
--- a/src/main/java/org/jfree/chart/block/FlowArrangement.java
+++ b/src/main/java/org/jfree/chart/block/FlowArrangement.java
@@ -175,11 +175,11 @@ public class FlowArrangement implements Arrangement, Serializable {
         double x = 0.0;
         double y = 0.0;
         double maxHeight = 0.0;
-        List<Block> itemsInRow = new ArrayList<>();
+        boolean haveItemsInRow = false;
         for (Block block : blocks) {
             Size2D size = block.arrange(g2, RectangleConstraint.NONE);
             if (x + size.width <= width) {
-                itemsInRow.add(block);
+                haveItemsInRow = true;
                 block.setBounds(
                     new Rectangle2D.Double(x, y, size.width, size.height)
                 );
@@ -187,7 +187,7 @@ public class FlowArrangement implements Arrangement, Serializable {
                 maxHeight = Math.max(maxHeight, size.height);
             }
             else {
-                if (itemsInRow.isEmpty()) {
+                if (!haveItemsInRow) {
                     // place in this row (truncated) anyway
                     block.setBounds(
                         new Rectangle2D.Double(
@@ -199,7 +199,6 @@ public class FlowArrangement implements Arrangement, Serializable {
                 }
                 else {
                     // start new row
-                    itemsInRow.clear();
                     x = 0.0;
                     y = y + maxHeight + this.verticalGap;
                     maxHeight = size.height;
@@ -209,7 +208,7 @@ public class FlowArrangement implements Arrangement, Serializable {
                         )
                     );
                     x = size.width + this.horizontalGap;
-                    itemsInRow.add(block);
+                    haveItemsInRow = true;
                 }
             }
         }

--- a/src/main/java/org/jfree/chart/plot/XYPlot.java
+++ b/src/main/java/org/jfree/chart/plot/XYPlot.java
@@ -3986,9 +3986,8 @@ public class XYPlot<S extends Comparable<S>> extends Plot
      *
      * @return A list of datasets.
      */
-    private List<XYDataset<S>> getDatasetsMappedToDomainAxis(Integer axisIndex) {
+    private List<XYDataset<S>> getDatasetsMappedToDomainAxis(Integer axisIndex, List<XYDataset<S>> result) {
         Args.nullNotPermitted(axisIndex, "axisIndex");
-        List<XYDataset<S>> result = new ArrayList<>();
         for (Entry<Integer, XYDataset<S>> entry : this.datasets.entrySet()) {
             int index = entry.getKey();
             List<Integer> mappedAxes = this.datasetToDomainAxesMap.get(index);
@@ -4013,9 +4012,8 @@ public class XYPlot<S extends Comparable<S>> extends Plot
      *
      * @return A list of datasets.
      */
-    private List<XYDataset<S>> getDatasetsMappedToRangeAxis(Integer axisIndex) {
+    private List<XYDataset<S>> getDatasetsMappedToRangeAxis(Integer axisIndex, List<XYDataset<S>> result) {
         Args.nullNotPermitted(axisIndex, "axisIndex");
-        List<XYDataset<S>> result = new ArrayList<>();
         for (Entry<Integer, XYDataset<S>> entry : this.datasets.entrySet()) {
             int index = entry.getKey();
             List<Integer> mappedAxes = this.datasetToRangeAxesMap.get(index);
@@ -4115,7 +4113,7 @@ public class XYPlot<S extends Comparable<S>> extends Plot
         int domainIndex = getDomainAxisIndex(axis);
         if (domainIndex >= 0) {
             isDomainAxis = true;
-            mappedDatasets.addAll(getDatasetsMappedToDomainAxis(domainIndex));
+            getDatasetsMappedToDomainAxis(domainIndex, mappedDatasets);
             if (domainIndex == 0) {
                 // grab the plot's annotations
                 for (XYAnnotation annotation : this.annotations) {
@@ -4130,7 +4128,7 @@ public class XYPlot<S extends Comparable<S>> extends Plot
         int rangeIndex = getRangeAxisIndex(axis);
         if (rangeIndex >= 0) {
             isDomainAxis = false;
-            mappedDatasets.addAll(getDatasetsMappedToRangeAxis(rangeIndex));
+            getDatasetsMappedToRangeAxis(rangeIndex, mappedDatasets);
             if (rangeIndex == 0) {
                 for (XYAnnotation annotation : this.annotations) {
                     if (annotation instanceof XYAnnotationBoundsInfo) {


### PR DESCRIPTION
Hi,

We find that there exist container inefficiencies in FlowArrangement.java and XYPlot.java.

For FlowArrangement.java, the List object `itemsInRow` only performs add, clear, and isEmpty operations.
And the objects in this list are never accessed.
Therefore, we can replace this list with a boolean variable.

For XYPlot.java, methods `getDatasetsMappedToDomainAxis` and `getDatasetsMappedToDomainAxis` 
allocate a List object `result` and return it as the parameter of `mappedDatasets.addAll` method.
The allocations of the `result` are redundant. We can simply pass mappedDatasets into these methods.

We discovered the above container inefficiencies using our tool cinst. The patch is submitted. 
Could you please check and accept it? We have tested the patch on our PC. The patched program works well.