### PR TITLE
Adding setter for symbols in SymbolAxis

### DIFF
--- a/src/main/java/org/jfree/chart/axis/SymbolAxis.java
+++ b/src/main/java/org/jfree/chart/axis/SymbolAxis.java
@@ -126,6 +126,15 @@ public class SymbolAxis extends NumberAxis implements Serializable {
     }
 
     /**
+     * Returns an array of the symbols for the axis.
+     *
+     * @return The symbols.
+     */
+    public void setSymbols(String[] symbols) {
+        this.symbols = Arrays.asList(symbols);
+    }
+
+    /**
      * Returns the flag that controls whether or not grid bands are drawn for 
      * the axis.  The default value is {@code true}. 
      *

--- a/src/main/java/org/jfree/chart/axis/SymbolAxis.java
+++ b/src/main/java/org/jfree/chart/axis/SymbolAxis.java
@@ -126,12 +126,13 @@ public class SymbolAxis extends NumberAxis implements Serializable {
     }
 
     /**
-     * Returns an array of the symbols for the axis.
+     * Sets the list of symbols to display instead of the numeric values. 
      *
-     * @return The symbols.
+     * @param symbols List of symbols.
      */
     public void setSymbols(String[] symbols) {
         this.symbols = Arrays.asList(symbols);
+        fireChangeEvent();
     }
 
     /**


### PR DESCRIPTION
# Is there a reason why Symbols are now allowed to be set after the creation of SymbolAxis? 
I have a use case where I need to set the symbols only after the Axis is created.
I am creating instances of all elements in the beginning, generating data and then assembling everything towards the end. 
